### PR TITLE
[WIP] Support Android (Termux)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +226,7 @@ dependencies = [
 name = "macchina-read"
 version = "0.1.2"
 dependencies = [
+ "android-properties",
  "cfg-if",
  "core-foundation",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "nix",
  "os-release",
  "sysctl",
+ "uname",
  "windows",
  "winreg",
 ]
@@ -483,6 +484,15 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,12 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
-
-[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +487,12 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -24,9 +24,12 @@ os-release = "0.1"
 core-foundation = "0.9.1"
 mach = "0.3.2"
 
-[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 sysctl = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = "0.4.0"
 winreg = "0.8.0"
+
+[target.'cfg(target_os = "android")'.dependencies]
+android-properties = "0.2.2"

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -14,15 +14,17 @@ libc = "0.2.88"
 [target.'cfg(target_os = "windows")'.build-dependencies]
 windows = "0.4.0"
 
-[target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))'.dependencies]
 nix = "0.20.0"
+
+[target.'cfg(any(target_os = "linux", target_os = "netbsd"))'.dependencies]
 os-release = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.1"
 mach = "0.3.2"
 
-[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))'.dependencies]
 sysctl = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/macchina-read/Cargo.toml
+++ b/macchina-read/Cargo.toml
@@ -33,3 +33,4 @@ winreg = "0.8.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-properties = "0.2.2"
+uname = "0.1.1"

--- a/macchina-read/src/android/mod.rs
+++ b/macchina-read/src/android/mod.rs
@@ -81,7 +81,6 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn username(&self) -> Result<String, ReadoutError> {
-        // Err(ReadoutError::MetricNotAvailable)
         crate::shared::whoami()
     }
 
@@ -117,11 +116,11 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn terminal(&self) -> Result<String, ReadoutError> {
-        if let Ok(terminal_env) = std::env::var("TERM") {
-            return Ok(terminal_env);
+        if let Ok(termux_version) = std::env::var("TERMUX_VERSION") {
+            return Ok(String::from("Termux"));
         }
 
-        //TODO check common terminal software like termux.
+        // TODO: investigate other terminal emulators
         Err(ReadoutError::MetricNotAvailable)
     }
 
@@ -141,6 +140,12 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
+        let max_freq = fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq")
+            .expect("")// TODO
+            .chars()
+            .filter(|c| c.is_digit(10))
+            .collect();
+        let khz = max_freq.parse::<u32>().unwrap_or(0);
         Err(ReadoutError::MetricNotAvailable)
         // Ok(crate::shared::cpu_model_name())
     }
@@ -212,7 +217,7 @@ impl ProductReadout for AndroidProductReadout {
     }
 
     fn vendor(&self) -> Result<String, ReadoutError> {
-        Ok(extra::ucfirst(AndroidProperty::new("ro.product.manufacturer")
+        Ok(extra::ucfirst(AndroidProperty::new("ro.product.brand")
             .value()
             .unwrap_or_default()
         ))

--- a/macchina-read/src/android/mod.rs
+++ b/macchina-read/src/android/mod.rs
@@ -1,12 +1,10 @@
 use crate::extra;
 use crate::traits::*;
 use nix::unistd;
-use std::fs;
-use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::time::Duration;
 use libc;
-use std::cell::UnsafeCell;
 use android_properties::AndroidProperty;
 use uname::uname;
 
@@ -116,7 +114,7 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn terminal(&self) -> Result<String, ReadoutError> {
-        if let Ok(termux_version) = std::env::var("TERMUX_VERSION") {
+        if let Ok(_) = std::env::var("TERMUX_VERSION") {
             return Ok(String::from("Termux"));
         }
 
@@ -140,19 +138,16 @@ impl GeneralReadout for AndroidGeneralReadout {
     }
 
     fn cpu_model_name(&self) -> Result<String, ReadoutError> {
-        let max_freq = fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq")
-            .expect("")// TODO
-            .chars()
-            .filter(|c| c.is_digit(10))
-            .collect();
-        let khz = max_freq.parse::<u32>().unwrap_or(0);
+        // let max_freq = fs::read_to_string("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq")
+            // .expect("")// TODO
+            // .chars()
+            // .filter(|c| c.is_digit(10))
+            // .collect();
+        // let khz = max_freq.parse::<u32>().unwrap_or(0);
         Err(ReadoutError::MetricNotAvailable)
-        // Ok(crate::shared::cpu_model_name())
     }
 
     fn uptime(&self) -> Result<String, ReadoutError> {
-        use std::time::{Duration, Instant};
-
         let mut time = libc::timespec {
             tv_sec: 0,
             tv_nsec: 0,

--- a/macchina-read/src/android/mod.rs
+++ b/macchina-read/src/android/mod.rs
@@ -1,0 +1,281 @@
+use crate::extra;
+use crate::traits::*;
+use nix::unistd;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use sysctl::{Ctl, Sysctl};
+
+pub struct AndroidBatteryReadout;
+
+pub struct AndroidKernelReadout {
+    os_release_ctl: Option<Ctl>,
+    os_type_ctl: Option<Ctl>,
+}
+
+pub struct AndroidGeneralReadout;
+
+pub struct AndroidMemoryReadout;
+
+pub struct AndroidProductReadout;
+
+pub struct AndroidPackageReadout;
+
+impl BatteryReadout for AndroidBatteryReadout {
+    fn new() -> Self {
+        AndroidBatteryReadout
+    }
+
+    fn percentage(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // let mut bat_path = Path::new("/sys/class/power_supply/BAT0/capacity");
+        // if !Path::exists(bat_path) {
+            // bat_path = Path::new("/sys/class/power_supply/BAT1/capacity");
+        // }
+//
+        // Ok(extra::pop_newline(fs::read_to_string(bat_path)?))
+    }
+
+    fn status(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // let mut bat_path = Path::new("/sys/class/power_supply/BAT0/status");
+        // if !Path::exists(bat_path) {
+            // bat_path = Path::new("/sys/class/power_supply/BAT1/status");
+        // }
+//
+        // Ok(extra::pop_newline(fs::read_to_string(bat_path)?))
+    }
+}
+
+impl KernelReadout for AndroidKernelReadout {
+    fn new() -> Self {
+        AndroidKernelReadout {
+            os_release_ctl: Ctl::new("kernel.osrelease").ok(),
+            os_type_ctl: Ctl::new("kernel.ostype").ok(),
+        }
+    }
+
+    fn os_release(&self) -> Result<String, ReadoutError> {
+        Ok(self
+            .os_release_ctl
+            .as_ref()
+            .ok_or(ReadoutError::MetricNotAvailable)?
+            .value_string()?)
+    }
+
+    fn os_type(&self) -> Result<String, ReadoutError> {
+        Ok(self
+            .os_type_ctl
+            .as_ref()
+            .ok_or(ReadoutError::MetricNotAvailable)?
+            .value_string()?)
+    }
+}
+
+impl GeneralReadout for AndroidGeneralReadout {
+    fn new() -> Self {
+        AndroidGeneralReadout
+    }
+
+    fn machine(&self) -> Result<String, ReadoutError> {
+        let product_readout = AndroidProductReadout::new();
+
+        let name = product_readout.name()?;
+        let family = product_readout.family().unwrap_or_default();
+        let version = product_readout.version().unwrap_or_default();
+
+        if family == name && family == version {
+            return Ok(family);
+        } else if version.is_empty() || version.len() <= 15 {
+            let vendor = product_readout.vendor().unwrap_or_default();
+
+            if !vendor.is_empty() {
+                return Ok(format!("{} {} {}", vendor, family, name));
+            }
+        }
+
+        Ok(version)
+    }
+
+    fn username(&self) -> Result<String, ReadoutError> {
+        // Err(ReadoutError::MetricNotAvailable)
+        crate::shared::whoami()
+    }
+
+    fn hostname(&self) -> Result<String, ReadoutError> {
+        let mut buf = [0u8; 64];
+        let hostname_cstr = unistd::gethostname(&mut buf);
+        match hostname_cstr {
+            Ok(hostname_cstr) => {
+                let hostname = hostname_cstr.to_str().unwrap_or("Unknown");
+                Ok(String::from(hostname))
+            }
+            Err(_e) => Err(ReadoutError::Other(String::from(
+                "ERROR: failed to fetch hostname from \"unistd::gethostname()\"",
+            ))),
+        }
+    }
+
+    fn distribution(&self) -> Result<String, ReadoutError> {
+        // getprop ro.build.version.release
+        let release = Command::new("getprop")
+            .arg("ro.build.version.release")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("ERROR: failed to spawn \"getprop\" process");
+
+        let output = release
+            .wait_with_output()
+            .expect("ERROR: failed to wait for \"getprop ro.build.version.release\" process to exit");
+
+        let version = String::from_utf8(output.stdout)
+            .expect("ERROR: \"getprop ro.build.version.release\" output was not valid UTF-8");
+
+        Ok(format!("Android {}", version))
+    }
+
+    fn desktop_environment(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // crate::shared::desktop_environment()
+    }
+
+    fn window_manager(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // crate::shared::window_manager()
+    }
+
+    fn terminal(&self) -> Result<String, ReadoutError> {
+        // Err(ReadoutError::MetricNotAvailable)
+        crate::shared::terminal()
+    }
+
+    fn shell(&self, shorthand: bool) -> Result<String, ReadoutError> {
+        // Err(ReadoutError::MetricNotAvailable)
+        crate::shared::shell(shorthand)
+    }
+
+    fn cpu_model_name(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::cpu_model_name())
+    }
+
+    fn uptime(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // crate::shared::uptime()
+    }
+}
+
+impl MemoryReadout for AndroidMemoryReadout {
+    fn new() -> Self {
+        AndroidMemoryReadout
+    }
+
+    fn total(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::get_meminfo_value("MemTotal"))
+    }
+
+    fn free(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::get_meminfo_value("MemFree"))
+    }
+
+    fn buffers(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::get_meminfo_value("Buffers"))
+    }
+
+    fn cached(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::get_meminfo_value("^Cached"))
+    }
+
+    fn reclaimable(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(crate::shared::get_meminfo_value("SReclaimable"))
+    }
+
+    fn used(&self) -> Result<u64, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // let total = self.total().unwrap();
+        // let free = self.free().unwrap();
+        // let cached = self.cached().unwrap();
+        // let reclaimable = self.reclaimable().unwrap();
+        // let buffers = self.buffers().unwrap();
+//
+        // if reclaimable != 0 {
+            // return Ok(total - free - cached - reclaimable - buffers);
+        // }
+//
+        // Ok(total - free - cached - buffers)
+    }
+}
+
+impl ProductReadout for AndroidProductReadout {
+    fn new() -> Self {
+        AndroidProductReadout
+    }
+
+    fn version(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(extra::pop_newline(fs::read_to_string(
+            // "/sys/class/dmi/id/product_version",
+        // )?))
+    }
+
+    fn vendor(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(extra::pop_newline(fs::read_to_string(
+            // "/sys/class/dmi/id/sys_vendor",
+        // )?))
+    }
+
+    fn family(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(extra::pop_newline(fs::read_to_string(
+            // "/sys/class/dmi/id/product_family",
+        // )?))
+    }
+
+    fn name(&self) -> Result<String, ReadoutError> {
+        Err(ReadoutError::MetricNotAvailable)
+        // Ok(extra::pop_newline(fs::read_to_string(
+            // "/sys/class/dmi/id/product_name",
+        // )?))
+    }
+}
+
+impl PackageReadout for AndroidPackageReadout {
+    fn new() -> Self {
+        AndroidPackageReadout
+    }
+
+    fn count_pkgs(&self) -> Result<String, ReadoutError> {
+        if extra::which("dpkg") {
+            let dpkg_output = Command::new("dpkg")
+                .arg("-l")
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("ERROR: failed to spawn \"dpkg\" process")
+                .stdout
+                .expect("ERROR: failed to open \"dpkg\" stdout");
+
+            let count = Command::new("wc")
+                .arg("-l")
+                .stdin(Stdio::from(dpkg_output))
+                .stdout(Stdio::piped())
+                .spawn()
+                .expect("ERROR: failed to spawn \"wc\" process");
+
+            let final_output = count
+                .wait_with_output()
+                .expect("ERROR: failed to wait for \"wc\" process to exit");
+            return Ok(String::from_utf8(final_output.stdout)
+                .expect("ERROR: \"dpkg -l | wc -l\" output was not valid UTF-8")
+                .trim()
+                .to_string());
+        }
+
+        Err(ReadoutError::MetricNotAvailable)
+    }
+}

--- a/macchina-read/src/android/mod.rs
+++ b/macchina-read/src/android/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 use libc;
-use android_properties::AndroidProperty;
+use android_properties::AndroidProperty; // TODO: build fails on android 7.1.1, lib links to extern __system_property_read_callback added in API 26, but offers a feature flag to support deprecated function
 use uname::uname;
 
 pub struct AndroidBatteryReadout;

--- a/macchina-read/src/android/mod.rs
+++ b/macchina-read/src/android/mod.rs
@@ -2,18 +2,19 @@ use crate::extra;
 use crate::traits::*;
 use nix::unistd;
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use libc;
 use std::cell::UnsafeCell;
 use android_properties::AndroidProperty;
+use uname::uname;
 
 pub struct AndroidBatteryReadout;
 
-pub struct AndroidKernelReadout;/* {
-    os_release_ctl: Option<Ctl>,
-    os_type_ctl: Option<Ctl>,
-}*/
+pub struct AndroidKernelReadout {
+    os_info: uname::Info,
+}
 
 pub struct AndroidGeneralReadout;
 
@@ -51,28 +52,17 @@ impl BatteryReadout for AndroidBatteryReadout {
 
 impl KernelReadout for AndroidKernelReadout {
     fn new() -> Self {
-        AndroidKernelReadout/* {
-            os_release_prop: AndroidProperty::new("").ok(),
-            os_type_ctl: Ctl::new("kernel/ostype").ok(),
-        }*/
+        AndroidKernelReadout {
+            os_info: uname().unwrap(),
+        }
     }
 
     fn os_release(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::MetricNotAvailable)
-        // Ok(self
-            // .os_release_ctl
-            // .as_ref()
-            // .ok_or(ReadoutError::MetricNotAvailable)?
-            // .value_string()?)
+        Ok(self.os_info.release.to_string())
     }
 
     fn os_type(&self) -> Result<String, ReadoutError> {
-        Err(ReadoutError::MetricNotAvailable)
-        // Ok(self
-            // .os_type_ctl
-            // .as_ref()
-            // .ok_or(ReadoutError::MetricNotAvailable)?
-            // .value_string()?)
+        Ok(self.os_info.sysname.to_string())
     }
 }
 

--- a/macchina-read/src/lib.rs
+++ b/macchina-read/src/lib.rs
@@ -37,7 +37,16 @@ cfg_if! {
         pub type GeneralReadout = windows::WindowsGeneralReadout;
         pub type ProductReadout = windows::WindowsProductReadout;
         pub type PackageReadout = windows::WindowsPackageReadout;
-    } else {
+    } else if #[cfg(target_os = "android")] {
+        mod android;
+
+        pub type BatteryReadout = android::AndroidBatteryReadout;
+        pub type KernelReadout = android::AndroidKernelReadout;
+        pub type MemoryReadout = android::AndroidMemoryReadout;
+        pub type GeneralReadout = android::AndroidGeneralReadout;
+        pub type ProductReadout = android::AndroidProductReadout;
+        pub type PackageReadout = android::AndroidPackageReadout;
+        } else {
         compiler_error!("This OS is currently not supported by macchina.");
     }
 }

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -10,12 +10,16 @@ use sysctl::SysctlError;
 
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use crate::extra;
+
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use nix::unistd;
+
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::process::{Command, Stdio};
+
 #[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use std::env;
+
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::fs;
 

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -5,12 +5,12 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::path::Path;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use sysctl::SysctlError;
 
-#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use crate::extra;
-#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 use nix::unistd;
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::process::{Command, Stdio};
@@ -124,7 +124,7 @@ pub(crate) fn window_manager() -> Result<String, ReadoutError> {
 }
 
 /// Read current terminal name using `ps`
-#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
 pub(crate) fn terminal() -> Result<String, ReadoutError> {
     //  ps -p $(ps -p $$ -o ppid=) o comm=
     //  $$ doesn't work natively in rust but its value can be

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -254,7 +254,7 @@ pub(crate) fn cpu_model_name() -> String {
 }
 
 /// Obtain the value of a specified field from `/proc/meminfo` needed to calculate memory usage
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 pub(crate) fn get_meminfo_value(value: &str) -> u64 {
     let file = fs::File::open("/proc/meminfo");
     match file {

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -14,8 +14,10 @@ use crate::extra;
 use nix::unistd;
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::process::{Command, Stdio};
+#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+use std::env;
 #[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
-use std::{env, fs};
+use std::fs;
 
 impl From<std::io::Error> for ReadoutError {
     fn from(e: Error) -> Self {

--- a/macchina-read/src/shared/mod.rs
+++ b/macchina-read/src/shared/mod.rs
@@ -5,19 +5,16 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::path::Path;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "android"))]
 use sysctl::SysctlError;
 
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use crate::extra;
-
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use nix::unistd;
-
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::process::{Command, Stdio};
-
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 use std::{env, fs};
 
 impl From<std::io::Error> for ReadoutError {
@@ -127,7 +124,7 @@ pub(crate) fn window_manager() -> Result<String, ReadoutError> {
 }
 
 /// Read current terminal name using `ps`
-#[cfg(any(target_os = "linux", target_os = "netbsd"))]
+#[cfg(any(target_os = "linux", target_os = "netbsd", target_os = "android"))]
 pub(crate) fn terminal() -> Result<String, ReadoutError> {
     //  ps -p $(ps -p $$ -o ppid=) o comm=
     //  $$ doesn't work natively in rust but its value can be

--- a/macchina/src/display.rs
+++ b/macchina/src/display.rs
@@ -116,6 +116,11 @@ impl Fail {
                 true,
                 String::from("(OK:DISABLED) Distribution -> Windows system detected, so the \
                 distribution is automatically hidden."),
+            ),
+            #[cfg(target_os = "android")]
+            distro: FailedComponent::new(
+                true,
+                String::from("(ERROR:DISABLED) Distribution -> Extracted from Android property \"ro.build.version.release\"."),
             )
         }
     }


### PR DESCRIPTION
This is a work in progress to support Android (initially probably just for Termux, not sure if anyone would want support of other terminal emulators). 

I'm looking for help, advice or comments. Also, I'm new to Rust, so feel free to bash the way I did things.

Some initial notes:
1. `/proc/cpuinfo` doesn't return the model name on the two devices I tested (Samsung A50 and Nexus 9 Tablet). I did a bunch of googling, and from what I gather, it's not easy to find out the model name on Android. There's a C library ([CPU INFOrmation](https://github.com/pytorch/cpuinfo)) that apparently can do it, but it has to check multiple Android properties and then do some logic to find a matching processor. We would have to have it as a dependency and update it when there's a new release. Also, I don't know how to call C from Rust yet. An alternative is to simply display the number of cores and the max frequency; that's what neofetch does.
2. I haven't figured out how to get into about the battery. The Linux way doesn't work. The data seems to only be available in the Android SDK in Java. Otherwise, Termux has a plugin app called Termux:API that adds a command to get battery stats, but it seems slow and it would require the user to have it installed.
3. To get the shell, I use the `$SHELL` environment variable, because I don't think Android allows you to change your shell, so the passwd file doesn't contain the shell info. Termux puts you in a modified environment though and you can change your shell there.
