### PR TITLE
Add macchina-stamp to determine out_dir

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,11 @@ fn main() {
         None => return,
         Some(outdir) => outdir,
     };
+
+    let stamp_path = std::path::Path::new(&outdir).join("macchina-stamp");
+    if let Err(err) = std::fs::File::create(&stamp_path) {
+        panic!("failed to write {}: {}", stamp_path.display(), err);
+    }
     cli::Opt::clap().gen_completions(name, Shell::Fish, &outdir);
     cli::Opt::clap().gen_completions(name, Shell::Bash, &outdir);
     // cli::Opt::clap().gen_completions(name, Shell::Zsh, &outdir);


### PR DESCRIPTION
As shown [here](https://users.rust-lang.org/t/how-to-get-out-dir-without-running-the-build-script/17239)
`OUT_DIR` will be needed when packaging in PKGBUILD / Other auto package generation methods.