### PR TITLE
Add command line argument for custom ascii art from file

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -16,13 +16,25 @@ lazy_static! {
 
 // TODO: Parse the file given more thorougly and use the custom colours supplied in the file
 // instead of some preset
-pub fn get_ascii_from_file(file_path: &Path) -> Result<Vec<Text<'static>>, io::Error> {
+pub fn get_ascii_from_file(
+    file_path: &Path,
+    override_color: Option<Color>,
+) -> Result<Vec<Text<'static>>, io::Error> {
     let file = File::open(file_path)?;
     let reader = BufReader::new(file);
     return Ok(vec![Text::from(
         reader
             .lines()
-            .map(|line| Spans::from(Span::styled(line.unwrap(), *BLUE)))
+            .map(|line| {
+                if let Some(override_color) = override_color {
+                    Spans::from(Span::styled(
+                        line.unwrap(),
+                        Style::default().fg(override_color),
+                    ))
+                } else {
+                    Spans::from(Span::from(line.unwrap()))
+                }
+            })
             .collect::<Vec<Spans>>(),
     )]);
 }

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::{self, BufRead, BufReader};
+use std::path::Path;
 use tui::style::{Color, Style};
 use tui::text::{Span, Spans, Text};
 
@@ -9,6 +12,19 @@ lazy_static! {
     static ref MAGENTA: Style = Style::default().fg(Color::Magenta);
     static ref WHITE: Style = Style::default().fg(Color::White);
     static ref BLACK: Style = Style::default().fg(Color::Black);
+}
+
+// TODO: Parse the file given more thorougly and use the custom colours supplied in the file
+// instead of some preset
+pub fn get_ascii_from_file(file_path: &Path) -> Result<Vec<Text<'static>>, io::Error> {
+    let file = File::open(file_path)?;
+    let reader = BufReader::new(file);
+    return Ok(vec![Text::from(
+        reader
+            .lines()
+            .map(|line| Spans::from(Span::styled(line.unwrap(), *BLUE)))
+            .collect::<Vec<Spans>>(),
+    )]);
 }
 
 #[cfg(target_os = "macos")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,7 @@ pub struct Opt {
     pub custom_ascii: Option<String>,
 
     #[structopt(
+        short = "A",
         long = "custom-ascii-color",
         help = "Overrides all colors in the ascii art with a specified one",
         requires = "custom-ascii",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,14 @@ pub struct Opt {
     pub custom_ascii: Option<String>,
 
     #[structopt(
+        long = "custom-ascii-color",
+        help = "Overrides all colors in the ascii art with a specified one",
+        requires = "custom-ascii",
+        conflicts_with = "no_ascii"
+    )]
+    pub custom_ascii_color: Option<MacchinaColor>,
+
+    #[structopt(
         long = "no-box",
         help = "Removes the box surrounding system information"
     )]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,13 @@ pub struct Opt {
     pub no_ascii: bool,
 
     #[structopt(
+        long = "custom-ascii",
+        help = "Specify your own ascii art from a file",
+        conflicts_with = "no_ascii"
+    )]
+    pub custom_ascii: Option<String>,
+
+    #[structopt(
         long = "no-box",
         help = "Removes the box surrounding system information"
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,11 +193,12 @@ fn main() -> Result<(), io::Error> {
 
     if let Some(file_path) = opt.custom_ascii {
         let file_path = PathBuf::from(file_path);
-        let ascii_art = ascii::get_ascii_from_file(&file_path)?;
-        if !ascii_art.is_empty() {
-            ascii_area = draw_ascii(ascii_art[0].to_owned(), &mut tmp_buffer);
+        let ascii_art = &ascii::get_ascii_from_file(&file_path)?[0];
+        // If the file is empty just default to disabled
+        if ascii_art.width() != 0 {
+            ascii_area = draw_ascii(ascii_art.to_owned(), &mut tmp_buffer);
         } else {
-            panic!("no text found");
+            ascii_area = Rect::new(0, 1, 0, tmp_buffer.area.height - 1);
         }
     } else {
         if readout_data.len() <= 6 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use atty::Stream;
 use data::Readout;
 use rand::Rng;
 use std::io::Stdout;
+use std::path::PathBuf;
 use std::str::FromStr;
 use tui::backend::{Backend, CrosstermBackend};
 use tui::buffer::{Buffer, Cell};
@@ -190,16 +191,26 @@ fn main() -> Result<(), io::Error> {
 
     let ascii_area;
 
-    if readout_data.len() <= 6 {
-        ascii_area = match (opt.no_ascii, select_ascii(true)) {
-            (false, Some(ascii)) => draw_ascii(ascii.to_owned(), &mut tmp_buffer),
-            _ => Rect::new(0, 1, 0, tmp_buffer.area.height - 1),
-        };
+    if let Some(file_path) = opt.custom_ascii {
+        let file_path = PathBuf::from(file_path);
+        let ascii_art = ascii::get_ascii_from_file(&file_path)?;
+        if !ascii_art.is_empty() {
+            ascii_area = draw_ascii(ascii_art[0].to_owned(), &mut tmp_buffer);
+        } else {
+            panic!("no text found");
+        }
     } else {
-        ascii_area = match (opt.no_ascii, select_ascii(false)) {
-            (false, Some(ascii)) => draw_ascii(ascii.to_owned(), &mut tmp_buffer),
-            _ => Rect::new(0, 1, 0, tmp_buffer.area.height - 1),
-        };
+        if readout_data.len() <= 6 {
+            ascii_area = match (opt.no_ascii, select_ascii(true)) {
+                (false, Some(ascii)) => draw_ascii(ascii.to_owned(), &mut tmp_buffer),
+                _ => Rect::new(0, 1, 0, tmp_buffer.area.height - 1),
+            };
+        } else {
+            ascii_area = match (opt.no_ascii, select_ascii(false)) {
+                (false, Some(ascii)) => draw_ascii(ascii.to_owned(), &mut tmp_buffer),
+                _ => Rect::new(0, 1, 0, tmp_buffer.area.height - 1),
+            };
+        }
     }
 
     let tmp_buffer_area = tmp_buffer.area;

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,11 @@ fn main() -> Result<(), io::Error> {
 
     if let Some(file_path) = opt.custom_ascii {
         let file_path = PathBuf::from(file_path);
-        let ascii_art = &ascii::get_ascii_from_file(&file_path)?[0];
+        let override_color = match opt.custom_ascii_color {
+            Some(color) => Some(color.get_color()),
+            None => None,
+        };
+        let ascii_art = &ascii::get_ascii_from_file(&file_path, override_color)?[0];
         // If the file is empty just default to disabled
         if ascii_art.width() != 0 {
             ascii_area = draw_ascii(ascii_art.to_owned(), &mut tmp_buffer);


### PR DESCRIPTION
Fantastic tool, but I felt limited by just having the default ascii art or no art at all so I added a simple command line option to take a file path for a file to be displayed as ascii art instead of the default one.

Currently this PR is a draft as I'm just polling interest if this is a desired feature. If it is, before a merge I'd also like to be able to parse in the ANSI colour information from the given file but haven't gotten to that yet, currently it just prints everything blue as a placeholder.

For a bunch of distro ascii art to test with check neofetch's repo: [https://github.com/dylanaraps/neofetch/blob/master/neofetch#L5426](https://github.com/dylanaraps/neofetch/blob/master/neofetch#L5426)

![image](https://user-images.githubusercontent.com/10660675/115420859-c80b9e80-a1fb-11eb-9a02-aa45a5b5a38e.png)