### PR TITLE
🎨 Add ability to list custom and built-in themes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -228,6 +228,12 @@ pub struct Opt {
     )]
     #[serde(skip_serializing, skip_deserializing)]
     pub export_config: bool,
+
+    #[structopt(
+        long = "list-themes",
+        help = "Lists all available themes: built-in and custom"
+    )]
+    pub list_themes: bool,
 }
 
 impl Default for Opt {
@@ -270,6 +276,7 @@ impl Default for Opt {
             box_inner_margin_x: 1,
             box_inner_margin_y: 0,
             export_config: false,
+            list_themes: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,9 @@ impl Opt {
         if args.theme.is_some() {
             self.theme = args.theme;
         }
+        if args.list_themes {
+            self.list_themes = true;
+        }
     }
 
     // Checks for conflicts between the different flags.

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,16 +196,22 @@ fn list_themes() {
     if let Some(dir) = dirs::data_local_dir() {
         let entries = libmacchina::extra::list_dir_entries(&dir.join("macchina/themes"));
         if !entries.is_empty() {
-            let custom_themes = entries
-                .iter()
-                .filter(|&x| {
-                    if let Some(ext) = libmacchina::extra::path_extension(&x) {
-                        return ext == "json";
-                    }
+            let custom_themes = entries.iter().filter(|&x| {
+                if let Some(ext) = libmacchina::extra::path_extension(&x) {
+                    ext == "json"
+                } else {
+                    false
+                }
+            });
 
-                    return false;
-                })
-                .into_iter();
+            if custom_themes.clone().count() == 0 {
+                println!(
+                    "\nNo custom themes were found in {}",
+                    dir.join("macchina/themes")
+                        .to_string_lossy()
+                        .bright_yellow()
+                )
+            }
 
             custom_themes.for_each(|x| {
                 if let Some(theme) = x.file_name() {
@@ -233,8 +239,8 @@ fn main() -> Result<(), io::Error> {
         let conflicts = opt.check_conflicts();
         if !conflicts.is_empty() {
             println!("\x1b[33mWarning:\x1b[0m Conflicting keys in config file:");
-            for i in 0..conflicts.len() {
-                println!("• {}", conflicts[i]);
+            for conflict in conflicts {
+                println!("• {}", conflict);
             }
             opt = arg_opt;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,7 @@ fn list_themes() {
         if !entries.is_empty() {
             let custom_themes = entries
                 .iter()
-                .find(|&x| {
+                .filter(|&x| {
                     if let Some(ext) = libmacchina::extra::path_extension(&x) {
                         return ext == "json";
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ mod format;
 mod theme;
 
 use cli::{MacchinaColor, Opt};
+use colored::Colorize;
 use std::io;
 use structopt::StructOpt;
+use theme::Themes;
 
 #[macro_use]
 extern crate lazy_static;
@@ -185,6 +187,36 @@ fn select_ascii(small: bool) -> Option<Text<'static>> {
     }
 }
 
+fn list_themes() {
+    let themes = Themes::variants();
+    themes
+        .iter()
+        .for_each(|x| println!("• {} (Built-in)", x.bright_green()));
+
+    if let Some(dir) = dirs::data_local_dir() {
+        let entries = libmacchina::extra::list_dir_entries(&dir.join("macchina/themes"));
+        if !entries.is_empty() {
+            let custom_themes = entries
+                .iter()
+                .find(|&x| {
+                    if let Some(ext) = libmacchina::extra::path_extension(&x) {
+                        return ext == "json";
+                    }
+
+                    return false;
+                })
+                .into_iter();
+
+            custom_themes.for_each(|x| {
+                if let Some(theme) = x.file_name() {
+                    let name = theme.to_string_lossy().replace(".json", "");
+                    println!("• {}", name.bright_blue());
+                }
+            });
+        }
+    }
+}
+
 fn main() -> Result<(), io::Error> {
     let mut opt: Opt;
     let config_opt = Opt::from_config();
@@ -217,6 +249,11 @@ fn main() -> Result<(), io::Error> {
 
     if opt.doctor {
         doctor::print_doctor(&readout_data);
+        return Ok(());
+    }
+
+    if opt.list_themes {
+        list_themes();
         return Ok(());
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,7 +1,7 @@
 use crate::data::ReadoutKey;
+use clap::arg_enum;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::str::FromStr;
 use tui::style::Color;
 
 /// Defines the different ways a key can be named, let's take the _OperatingSystem variant_ for example: \
@@ -162,27 +162,14 @@ impl BarStyle {
     }
 }
 
-/// This stores the pre-defined themes
-#[derive(Debug)]
-pub enum Themes {
+arg_enum! {
+    #[derive(Debug)]
+    pub enum Themes {
     Hydrogen,
     Helium,
     Lithium,
     Beryllium,
     Boron,
-}
-
-impl FromStr for Themes {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s.to_ascii_lowercase().as_str() {
-            "hydrogen" => Self::Hydrogen,
-            "helium" => Self::Helium,
-            "lithium" => Self::Lithium,
-            "beryllium" => Self::Beryllium,
-            "boron" => Self::Boron,
-            &_ => return Err(s.to_ascii_lowercase()),
-        })
     }
 }
 


### PR DESCRIPTION
`--list-themes` can tell the user if `macchina` was able to read their custom theme and also prints built-in themes.

![image](https://user-images.githubusercontent.com/35816711/118518775-5fe3a600-b730-11eb-9888-d81160cc80c6.png)
