### PR TITLE
Warning for conflicting theme names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod theme;
 use cli::{MacchinaColor, Opt};
 use colored::Colorize;
 use std::io;
+use std::path::Path;
 use structopt::StructOpt;
 use theme::Themes;
 
@@ -91,6 +92,13 @@ fn create_theme(opt: &Opt) -> Theme {
     let mut theme;
     if let Some(opt_theme) = &opt.theme {
         if let Ok(ts) = theme::Themes::from_str(opt_theme) {
+            if let Some(dir) = dirs::data_local_dir() {
+                if !opt.list_themes
+                    && Path::exists(&dir.join(format!("macchina/themes/{}.json", opt_theme)))
+                {
+                    println!("\x1b[33mWarning:\x1b[0m Custom theme with conflicting inbuilt theme named {} found", &opt_theme);
+                }
+            }
             theme = Theme::new(ts);
         } else if let Ok(custom_theme) = theme::CustomTheme::get_theme(opt_theme) {
             theme = Theme::from(custom_theme);
@@ -189,6 +197,16 @@ fn select_ascii(small: bool) -> Option<Text<'static>> {
 
 fn list_themes() {
     let themes = Themes::variants();
+    if let Some(dir) = dirs::data_local_dir() {
+        for theme in themes.iter() {
+            if Path::exists(&dir.join(format!("macchina/themes/{}.json", theme))) {
+                println!(
+                    "\x1b[33mWarning:\x1b[0m Custom theme with conflicting inbuilt theme named {} found",
+                    theme
+                );
+            }
+        }
+    }
     themes
         .iter()
         .for_each(|x| println!("• {} (Built-in)", x.bright_green()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn create_theme(opt: &Opt) -> Theme {
                 if !opt.list_themes
                     && Path::exists(&dir.join(format!("macchina/themes/{}.json", opt_theme)))
                 {
-                    println!("\x1b[33mWarning:\x1b[0m Custom theme with conflicting inbuilt theme named {} found", &opt_theme);
+                    println!("\x1b[33mWarning:\x1b[0m Custom theme has the same name as built-in theme: {}", &opt_theme);
                 }
             }
             theme = Theme::new(ts);
@@ -201,7 +201,7 @@ fn list_themes() {
         for theme in themes.iter() {
             if Path::exists(&dir.join(format!("macchina/themes/{}.json", theme))) {
                 println!(
-                    "\x1b[33mWarning:\x1b[0m Custom theme with conflicting inbuilt theme named {} found",
+                    "\x1b[33mWarning:\x1b[0m Custom theme has the same name as built-in theme: {}",
                     theme
                 );
             }


### PR DESCRIPTION
Check happens in both normal macchina run as well as --list-themes
But in case of `macchina` it only happens for the specified theme and not for all the inbuilt themes so only 1 check.