### PR TITLE
Display processor model without core count

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -111,6 +111,7 @@ pub fn get_all_readouts<'a>(
     should_display: Vec<ReadoutKey>,
 ) -> Vec<Readout<'a>> {
     use crate::format::cpu as format_cpu;
+    use crate::format::cpu_only as format_cpu_only;
     use crate::format::cpu_usage as format_cpu_usage;
     use crate::format::host as format_host;
     use crate::format::uptime as format_uptime;
@@ -251,9 +252,10 @@ pub fn get_all_readouts<'a>(
             (Ok(m), Ok(c)) => {
                 readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu(&m, c)))
             }
-            (Err(e), _) | (_, Err(e)) => {
-                readout_values.push(Readout::new_err(ReadoutKey::Processor, e))
+            (Ok(m), _) => {
+                readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu_only(&m)))
             }
+            (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::Processor, e)),
         }
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -97,12 +97,16 @@ pub fn memory(total: u64, used: u64) -> String {
     format!("{}/{}", used, total)
 }
 
+/// This function should return a new `String` constructed from the value \
+/// returned by `traits::GeneralReadout::cpu_model_name()`
+pub fn cpu_only(model_name: &str) -> String {
+    model_name.replace("(TM)", "™").replace("(R)", "®")
+}
+
 /// This function should return a new `String` constructed from the values \
 /// returned by `traits::GeneralReadout::cpu_model_name()` and `num_cpus::get()`
 pub fn cpu(model_name: &str, cpu_cores: usize) -> String {
-    format!("{} ({})", model_name, cpu_cores)
-        .replace("(TM)", "™")
-        .replace("(R)", "®")
+    format!("{} ({})", cpu_only(model_name), cpu_cores)
 }
 
 pub fn cpu_usage(used: usize) -> String {


### PR DESCRIPTION
This only applies if the number of CPU cores cannot be read.
For example when using Windows this allows to show the processor model even though `GeneralReadout::cpu_cores()` is not implemented.