### PR TITLE
Add an option to specify which shell 🐢 to fetch (default/current)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libmacchina"
-version = "0.6.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec74aad09edcd3da3f7b3221e01473f18b732acfcf6318e748c3deee9e7922d2"
+checksum = "365b21b1987178d5346d3a9bc8c4f752a04b624b4c1a631a108204d4ca0169a6"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libmacchina"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53edfe6e652dce00e5d30da534eff160d00b4df046c46bc9604c38a5981d998"
+checksum = "013d322b82a98e46d622d69bd66191d7670f96a4c353b9ef94d0f595f6427ffb"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libmacchina"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365b21b1987178d5346d3a9bc8c4f752a04b624b4c1a631a108204d4ca0169a6"
+checksum = "c53edfe6e652dce00e5d30da534eff160d00b4df046c46bc9604c38a5981d998"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aparato"
-version = "6.0.1"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48892a7ae578d713f0af7a71ac3223bbe7d363717deadd6e62d626c340694cd8"
+checksum = "724b4da16efbef93119f185f1c34f573023b11bd90ef5a3fd857d99fed85e648"
 dependencies = [
  "cfg-if",
  "hex",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -333,15 +333,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libmacchina"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cb9a778a0b05c5058016ff13962974a660578c597e789c3634555b987bb08a"
+checksum = "c2511c0c011f68c078e58afa8283fd592c398b3bb770effe4a7414a6f65890dc"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libmacchina"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2511c0c011f68c078e58afa8283fd592c398b3bb770effe4a7414a6f65890dc"
+checksum = "ec74aad09edcd3da3f7b3221e01473f18b732acfcf6318e748c3deee9e7922d2"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.6.2"
+libmacchina = "0.6.3"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }
@@ -29,7 +29,7 @@ serde_json = "1.0.64"
 google_speech = { version = "0.1.0" , optional = true }
 
 [build-dependencies]
-libmacchina = "0.6.2"
+libmacchina = "0.6.3"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.7.6"
+libmacchina = "0.7.7"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }
@@ -29,7 +29,7 @@ serde_json = "1.0.64"
 google_speech = { version = "0.1.0" , optional = true }
 
 [build-dependencies]
-libmacchina = "0.7.6"
+libmacchina = "0.7.7"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.6.3"
+libmacchina = "0.7.6"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }
@@ -29,7 +29,7 @@ serde_json = "1.0.64"
 google_speech = { version = "0.1.0" , optional = true }
 
 [build-dependencies]
-libmacchina = "0.6.3"
+libmacchina = "0.7.6"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.7.7"
+libmacchina = "0.7.8"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }
@@ -29,7 +29,7 @@ serde_json = "1.0.64"
 google_speech = { version = "0.1.0" , optional = true }
 
 [build-dependencies]
-libmacchina = "0.7.7"
+libmacchina = "0.7.8"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }

--- a/macchina.toml
+++ b/macchina.toml
@@ -1,20 +1,16 @@
 # Disables color.
-# Conflicts with: color, separator_color
 no_color = false 
 
 # Hides the separator.
-# Conflicts with: separator_color
 no_separator = false 
 
 # Hides bar delimiters
 no_bar_delimiter = true 
 
 # Hides the title of the box surrounding system information
-# Conflicts with: box_title
 no_title = false 
 
 # Disables the box surrounding system information.
-# Conflicts with: box_title
 no_box = false 
 
 # Disables ASCII art
@@ -27,7 +23,6 @@ palette = true
 bar = true
 
 # Prefer small ASCII variant.
-# Conflicts with: no_ascii
 small_ascii = false 
 
 # Randomizes the color of the keys each time your run the program 
@@ -37,7 +32,6 @@ random_color = false
 random_sep_color = false
 
 # Specify a color for the keys.
-# Conflicts with: no_color
 # Accepted values (case-sensitive):
 #   - White
 #   - Black
@@ -50,7 +44,6 @@ random_sep_color = false
 color = "Blue"
 
 # Specify a color for the separator.
-# Conflicts with: no_color
 # Accepted values (case-sensitive):
 #   - White
 #   - Black
@@ -69,15 +62,12 @@ short_uptime = true
 long_shell = false 
 
 # Specify the title of the box
-# Conflicts with: no_title.
 box_title = " Macchina "
 
 # Specify the horizontal inner margin value of the box surrounding system information.
-# Conflicts with: no_box
 box_inner_margin_x = 1
 
 # Specify the vertical inner margin value of the box surrounding system information.
-# Conflicts with: no_box
 box_inner_margin_y = 0
 
 # Specify the theme to use
@@ -111,8 +101,9 @@ theme = "Beryllium"
 #   - Terminal
 #   - Shell
 #   - Uptime
-#   - Processor
-#   - ProcessorUsage
+#   - CPU
+#   - GPU
+#   - CPULoad
 #   - Memory
 #   - Battery
 # Example:
@@ -134,8 +125,9 @@ hide = []
 #   - Terminal
 #   - Shell
 #   - Uptime
-#   - Processor
-#   - ProcessorUsage
+#   - CPU
+#   - GPU
+#   - CPULoad
 #   - Memory
 #   - Battery
 # Example:

--- a/macchina.toml
+++ b/macchina.toml
@@ -1,34 +1,34 @@
 # Disables color.
-no_color = false 
+no_color = false
 
 # Hides the separator.
-no_separator = false 
+no_separator = false
 
 # Hides bar delimiters
-no_bar_delimiter = true 
+no_bar_delimiter = true
 
 # Hides the title of the box surrounding system information
-no_title = false 
+no_title = false
 
 # Disables the box surrounding system information.
-no_box = false 
+no_box = false
 
 # Disables ASCII art
-no_ascii = false 
+no_ascii = false
 
 # Displays a palette of your active colorscheme
-palette = true 
+palette = true
 
-# Turns data into bars for specific readouts 
+# Turns data into bars for specific readouts
 bar = true
 
 # Prefer small ASCII variant.
-small_ascii = false 
+small_ascii = false
 
-# Randomizes the color of the keys each time your run the program 
+# Randomizes the color of the keys each time your run the program
 random_color = false
 
-# Randomizes the color of the separator each time your run the program 
+# Randomizes the color of the separator each time your run the program
 random_sep_color = false
 
 # Specify a color for the keys.
@@ -56,10 +56,10 @@ color = "Blue"
 separator_color = "Blue"
 
 # Shorten uptime format
-short_uptime = true 
+short_uptime = true
 
 # Lengthen shell output
-long_shell = false 
+long_shell = false
 
 # Specify the title of the box
 box_title = " Macchina "
@@ -80,8 +80,8 @@ box_inner_margin_y = 0
 #
 # Custom themes are also supported, they should be placed
 # in $XDG_DATA_HOME/macchina/themes and must be a JSON file.
-# 
-# To set 'foobar' as a theme, place foobar.json 
+#
+# To set 'foobar' as a theme, place foobar.json
 # in $XDG_DATA_HOME/macchina/themes
 # and set theme = "foobar" (case-sensitive)
 theme = "Beryllium"
@@ -90,7 +90,7 @@ theme = "Beryllium"
 # Conflicts with: show_only
 # Accepted values (case-sensitive):
 #   - Host
-#   - Machine 
+#   - Machine
 #   - Kernel
 #   - Distribution
 #   - OperatingSystem
@@ -111,10 +111,10 @@ theme = "Beryllium"
 hide = []
 
 # Displays only the specified readouts.
-# Conflicts with: hide 
+# Conflicts with: hide
 # Accepted values (case-sensitive):
 #   - Host
-#   - Machine 
+#   - Machine
 #   - Kernel
 #   - Distribution
 #   - OperatingSystem

--- a/macchina.toml
+++ b/macchina.toml
@@ -61,6 +61,9 @@ short_uptime = true
 # Lengthen shell output
 long_shell = false
 
+# Toggle between the current shell or the default one
+current_shell = no
+
 # Specify the title of the box
 box_title = " Macchina "
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -167,8 +167,8 @@ pub struct Opt {
 
     #[structopt(
         short = "W",
-        long = "which-shell",
-        help = "Toggles between the current shell or default one"
+        long = "current-shell",
+        help = "Toggles between the current shell or the default one"
     )]
     pub current_shell: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::data;
-use clap::{App, arg_enum};
+use clap::{arg_enum, App};
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use structopt::StructOpt;
@@ -165,7 +165,11 @@ pub struct Opt {
     #[structopt(short = "S", long = "long-shell", help = "Lengthens shell output")]
     pub long_shell: bool,
 
-    #[structopt(short = "W", long = "which-shell", help = "Toggles between the current shell or default one")]
+    #[structopt(
+        short = "W",
+        long = "which-shell",
+        help = "Toggles between the current shell or default one"
+    )]
     pub current_shell: bool,
 
     #[structopt(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::data;
-use clap::{arg_enum, App};
+use clap::{App, arg_enum};
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use structopt::StructOpt;
@@ -165,6 +165,9 @@ pub struct Opt {
     #[structopt(short = "S", long = "long-shell", help = "Lengthens shell output")]
     pub long_shell: bool,
 
+    #[structopt(short = "W", long = "which-shell", help = "Toggles between the current shell or default one")]
+    pub current_shell: bool,
+
     #[structopt(
     short = "t",
     long = "theme",
@@ -221,6 +224,7 @@ pub struct Opt {
         default_value = "0"
     )]
     pub box_inner_margin_y: u16,
+
     #[structopt(
         long = "export-config",
         help = "Prints the config file to stdout",
@@ -274,6 +278,7 @@ impl Default for Opt {
             doctor: false,
             short_uptime: false,
             long_shell: false,
+            current_shell: false,
             theme: None,
             box_title: None,
             box_inner_margin_x: 1,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,28 +260,22 @@ impl Default for Opt {
             no_box: false,
 
             color: None,
-            bar: false,
-
             separator_color: None,
             random_color: false,
             random_sep_color: false,
-
-            hide: None,
-            show_only: None,
-
-            doctor: false,
-
-            short_uptime: false,
-            long_shell: false,
-
-            theme: None,
-
-            box_title: None,
 
             custom_ascii: None,
             custom_ascii_color: None,
             small_ascii: false,
 
+            bar: false,
+            hide: None,
+            show_only: None,
+            doctor: false,
+            short_uptime: false,
+            long_shell: false,
+            theme: None,
+            box_title: None,
             box_inner_margin_x: 1,
             box_inner_margin_y: 0,
             export_config: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,22 +124,6 @@ impl Opt {
             conflicts.push("hide and show_only");
         }
 
-        if self.separator_color.is_some() && self.no_separator {
-            conflicts.push("separator_color and no_separator");
-        }
-
-        if self.color.is_some() && self.no_color {
-            conflicts.push("color and no_color");
-        }
-
-        if self.separator_color.is_some() && self.no_color {
-            conflicts.push("separator_color and no_color");
-        }
-
-        if self.box_title.is_some() && self.no_title {
-            conflicts.push("box_title and no_title");
-        }
-
         conflicts
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -27,7 +27,6 @@ arg_enum! {
         Terminal,
         Uptime,
         CPU,
-        GPU,
         CPULoad,
         Memory,
         Battery,
@@ -282,18 +281,6 @@ pub fn get_all_readouts<'a>(
             (Ok(m), Ok(c)) => readout_values.push(Readout::new(ReadoutKey::CPU, format_cpu(&m, c))),
             (Ok(m), _) => readout_values.push(Readout::new(ReadoutKey::CPU, format_cpu_only(&m))),
             (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::CPU, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::GPU) {
-        match general_readout.gpus() {
-            Ok(gpus) => {
-                for g in gpus {
-                    readout_values.push(Readout::new(ReadoutKey::GPU, g));
-                }
-            }
-
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Uptime, e)),
         }
     }
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,8 +1,8 @@
 use crate::cli::Opt;
 use crate::theme::Theme;
 use clap::arg_enum;
-use libmacchina::traits::{ReadoutError, ShellKind};
 use libmacchina::traits::ShellFormat;
+use libmacchina::traits::{ReadoutError, ShellKind};
 use libmacchina::{BatteryReadout, GeneralReadout, KernelReadout, MemoryReadout, PackageReadout};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -242,19 +242,19 @@ pub fn get_all_readouts<'a>(
                     Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
                     Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
                 };
-            },
+            }
             (false, true) => {
-                match general_readout.shell(ShellFormat::Relative, ShellKind::Default) {
+                match general_readout.shell(ShellFormat::Relative, ShellKind::Current) {
                     Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
                     Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
                 };
-            },
+            }
             (true, true) => {
                 match general_readout.shell(ShellFormat::Absolute, ShellKind::Current) {
                     Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
                     Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
                 };
-            },
+            }
             _ => {
                 match general_readout.shell(ShellFormat::Relative, ShellKind::Current) {
                     Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,7 +1,7 @@
 use crate::cli::Opt;
 use crate::theme::Theme;
 use clap::arg_enum;
-use libmacchina::traits::ReadoutError;
+use libmacchina::traits::{ReadoutError, ShellKind};
 use libmacchina::traits::ShellFormat;
 use libmacchina::{BatteryReadout, GeneralReadout, KernelReadout, MemoryReadout, PackageReadout};
 use serde::{Deserialize, Serialize};
@@ -236,15 +236,31 @@ pub fn get_all_readouts<'a>(
     }
 
     if should_display.contains(&ReadoutKey::Shell) {
-        match opt.long_shell {
-            true => match general_readout.shell(ShellFormat::Absolute) {
-                Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
-                Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+        match (opt.long_shell, opt.current_shell) {
+            (true, false) => {
+                match general_readout.shell(ShellFormat::Absolute, ShellKind::Default) {
+                    Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
+                    Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+                };
             },
-            false => match general_readout.shell(ShellFormat::Relative) {
-                Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
-                Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+            (false, true) => {
+                match general_readout.shell(ShellFormat::Relative, ShellKind::Default) {
+                    Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
+                    Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+                };
             },
+            (true, true) => {
+                match general_readout.shell(ShellFormat::Absolute, ShellKind::Current) {
+                    Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
+                    Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+                };
+            },
+            _ => {
+                match general_readout.shell(ShellFormat::Relative, ShellKind::Current) {
+                    Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
+                    Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+                };
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use tui::buffer::{Buffer, Cell};
 use tui::layout::{Margin, Rect};
 use tui::style::Color;
 use tui::text::Text;
-use tui::widgets::{Block, BorderType, Borders, Paragraph, Widget};
+use tui::widgets::{Block, BorderType, Borders, Paragraph, Widget, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 fn create_backend() -> CrosstermBackend<Stdout> {
@@ -64,7 +64,9 @@ fn draw_ascii(ascii: Text<'static>, tmp_buffer: &mut Buffer) -> Rect {
         height: ascii.height() as u16,
     };
 
-    Paragraph::new(ascii).render(ascii_rect, tmp_buffer);
+    Paragraph::new(ascii)
+        .wrap(Wrap { trim: false })
+        .render(ascii_rect, tmp_buffer);
     ascii_rect
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -82,11 +82,6 @@ impl ReadoutKey {
                 values.insert(&AbbreviationType::Alternative, "Cpu");
                 values.insert(&AbbreviationType::Long, "Processor");
             }
-            ReadoutKey::GPU => {
-                values.insert(&AbbreviationType::Classic, "GPU");
-                values.insert(&AbbreviationType::Alternative, "Gpu");
-                values.insert(&AbbreviationType::Long, "Graphics Processor");
-            }
             ReadoutKey::CPULoad => {
                 values.insert(&AbbreviationType::Classic, "CPU%");
                 values.insert(&AbbreviationType::Alternative, "Cp%");

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -77,12 +77,17 @@ impl ReadoutKey {
                 values.insert(&AbbreviationType::Alternative, "Upt");
                 values.insert(&AbbreviationType::Long, "Uptime");
             }
-            ReadoutKey::Processor => {
+            ReadoutKey::CPU => {
                 values.insert(&AbbreviationType::Classic, "CPU");
                 values.insert(&AbbreviationType::Alternative, "Cpu");
                 values.insert(&AbbreviationType::Long, "Processor");
             }
-            ReadoutKey::ProcessorUsage => {
+            ReadoutKey::GPU => {
+                values.insert(&AbbreviationType::Classic, "GPU");
+                values.insert(&AbbreviationType::Alternative, "Gpu");
+                values.insert(&AbbreviationType::Long, "Graphics Processor");
+            }
+            ReadoutKey::CPULoad => {
                 values.insert(&AbbreviationType::Classic, "CPU%");
                 values.insert(&AbbreviationType::Alternative, "Cp%");
                 values.insert(&AbbreviationType::Long, "Processor Usage");


### PR DESCRIPTION
As requested by @thorion3006; this PR includes an option to define what shell macchina fetches.

If `current_shell` is set to *false*, the shell readout will display the user's default shell. Otherwise it'll do some magic to figure out which shell macchina ran in and display that instead.

:rocket: