### PR TITLE
Bump libmacchina version to v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "libmacchina"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54539d2333f9dc49a16cc0db36f5f28a5fbdb65f0b4905114dd19e39b186c4ac"
+checksum = "b09a572e6f5bb38cec749d6400d5f345ebe2d769b64b9214a7ccdc99225cecc1"
 dependencies = [
  "aparato",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.8.1"
+libmacchina = "0.8.2"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README_CARGO.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = "0.8.2"
+libmacchina = "0.8.3"
 bytesize = "1.0.1"
 clap = "2.33.3"
 tui = { version = "0.15.0", default-features = false, features = ['crossterm'] }


### PR DESCRIPTION
libmacchina v0.8.2 includes a change that addresses #131 by only grabbing the first line of a card's `modes` file from `/sys/class/drm`