### PR TITLE
Installation instructions for nix as a package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,12 @@ cd macchina
 makepkg -si
 ```
 
-### NixOS
+### Nix
+
+Where `<channel>` is probably `nixpkgs` or `nixos`:
 
 ```bash
-nix-env -iA nixos.macchina
+nix-env -iA <channel>.macchina
 ```
 
 _Macchina's_


### PR DESCRIPTION
NixOS is an OS.

Nix is a package manager that can be used on lots of OSes.

We could also have said `nix-env -i macchina`, but by all accounts that's quite slow to execute.