### PR TITLE
chore: bring back `export-config` flag

### DIFF
--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -16,82 +16,76 @@ jobs:
           - x86_64-unknown-netbsd
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
+
         include:
           - os: ubuntu-latest
             name: Linux
             target: x86_64-unknown-linux-gnu
             cross: false
             strip: true
-            test: true
 
           - os: macos-latest
             name: macOS
             target: x86_64-apple-darwin
             cross: false
             strip: true
-            test: true
 
           - os: windows-latest
             name: Windows
             target: x86_64-pc-windows-msvc
             cross: false
             strip: true
-            test: true
 
           - os: ubuntu-latest
             name: NetBSD
             target: x86_64-unknown-netbsd
             cross: true
             strip: true
-            test: false
 
           - os: ubuntu-latest
             name: Android
             target: aarch64-linux-android
             cross: true
             strip: true
-            test: false
 
           - os: ubuntu-latest
             name: Linux
             target: aarch64-unknown-linux-gnu
             cross: true
             strip: true
-            test: true
 
     steps:
-      - name: Checkout Code
+      - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup rust toolchain
+      - name: Bootstrap
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: clippy
+          components: rustfmt, clippy
           target: ${{ matrix.target }}
 
-      - name: Cargo Clippy
+      - name: Formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          use-cross: ${{ matrix.cross }}
+        continue-on-error: false
+
+      - name: Lints
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --target=${{ matrix.target }} -- --no-deps -D clippy::all
           use-cross: ${{ matrix.cross }}
-        continue-on-error: true
+        continue-on-error: false
 
-      - name: Cargo Build
+      - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target=${{ matrix.target }}
           use-cross: ${{ matrix.cross }}
-
-      - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.target }}
-          use-cross: ${{ matrix.cross }}
-        if: ${{ matrix.test }}
 
       - name: Doctor
         uses: actions-rs/cargo@v1

--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 
-name: Check target
+name: CI
 
 jobs:
   checks:

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -22,7 +22,7 @@ pub enum AsciiSize {
     Small,
 }
 
-pub fn list_ascii_artists() -> Result<()> {
+pub fn list_ascii_artists() {
     println!(
         "- FreeBSD ASCII art (small variant) was taken from {}' {}",
         "Dylan Araps".bold(),
@@ -49,8 +49,6 @@ pub fn list_ascii_artists() -> Result<()> {
         "- Linux ASCII art (small variant) was taken from {}",
         "Christopher Johnson's ASCII art collection".bold(),
     );
-
-    Ok(())
 }
 
 pub fn select_ascii(ascii_size: AsciiSize) -> Option<Text<'static>> {

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -353,7 +353,7 @@ pub(crate) fn get_ascii_art(size: AsciiSize) -> Vec<Text<'static>> {
 
             vec![Text::from(
                 art.iter()
-                    .map(|f| Spans::from(f.to_owned()))
+                    .map(|f| f.to_owned())
                     .collect::<Vec<Spans>>(),
             )]
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,15 @@ pub struct Opt {
     pub config: Option<std::path::PathBuf>,
 
     #[structopt(
+        long = "export-config",
+        short = "e",
+        help = "Prints a template configuration file to stdout",
+        conflicts_with = "doctor"
+    )]
+    #[serde(skip_serializing, skip_deserializing)]
+    pub export_config: bool,
+
+    #[structopt(
         long = "ascii-artists",
         help = "Lists the original artists of the ASCII art used by macchina"
     )]
@@ -100,15 +109,16 @@ pub struct Opt {
 impl Default for Opt {
     fn default() -> Self {
         Opt {
-            version: false,
-            doctor: false,
+            export_config: false,
             current_shell: false,
             long_shell: false,
             long_uptime: false,
-            long_kernel: true,
+            long_kernel: false,
             list_themes: false,
             ascii_artists: false,
             physical_cores: false,
+            version: false,
+            doctor: false,
             config: None,
             theme: None,
             show: None,
@@ -125,6 +135,10 @@ impl Opt {
 
         if args.doctor {
             self.doctor = true;
+        }
+
+        if args.export_config {
+            self.export_config = true;
         }
 
         if args.current_shell {
@@ -172,20 +186,21 @@ impl Opt {
         }
     }
 
-    pub fn get_options(arg_opt: Opt) -> Opt {
-        let config_opt = match arg_opt.config {
-            Some(_) => config::read_config(&arg_opt.config.clone().unwrap()),
+    pub fn get_options() -> Opt {
+        let args = Opt::from_args();
+        let config_opt = match args.config {
+            Some(_) => config::read_config(&args.config.clone().unwrap()),
             None => config::get_config(),
         };
 
         match config_opt {
             Ok(mut config) => {
-                config.parse_args(arg_opt);
+                config.parse_args(args);
                 config
             }
             Err(e) => {
                 error::print_errors(e);
-                arg_opt
+                args
             }
         }
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -125,7 +125,7 @@ pub fn should_display(opt: &Opt) -> Vec<ReadoutKey> {
 pub fn get_all_readouts<'a>(
     opt: &Opt,
     theme: &Theme,
-    should_display: Vec<ReadoutKey>,
+    should_display: &[ReadoutKey],
 ) -> Vec<Readout<'a>> {
     use crate::format::cpu as format_cpu;
     use crate::format::cpu_only as format_cpu_only;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,24 +23,31 @@ use tui::layout::Rect;
 extern crate lazy_static;
 
 fn main() -> Result<()> {
-    let arg_opt = Opt::from_args();
-    let opt = Opt::get_options(arg_opt);
+    let opt = Opt::get_options();
 
     if opt.version {
-        return get_version();
+        get_version();
+        return Ok(());
     }
 
     if opt.ascii_artists {
-        return ascii::list_ascii_artists();
+        ascii::list_ascii_artists();
+        return Ok(());
     }
 
     if opt.list_themes {
-        return theme::list_themes(&opt);
+        theme::list_themes(&opt);
+        return Ok(());
+    }
+
+    if opt.export_config {
+        println!("{}", toml::to_string(&Opt::from_args()).unwrap());
+        return Ok(());
     }
 
     let theme = theme::create_theme(&opt);
     let should_display = data::should_display(&opt);
-    let readout_data = data::get_all_readouts(&opt, &theme, should_display);
+    let readout_data = data::get_all_readouts(&opt, &theme, &should_display);
 
     if opt.doctor {
         doctor::print_doctor(&readout_data);
@@ -49,7 +56,6 @@ fn main() -> Result<()> {
 
     const MAX_ASCII_HEIGHT: usize = 50;
     const MINIMUM_READOUTS_TO_PREFER_SMALL_ASCII: usize = 8;
-
     let mut backend = buffer::create_backend();
     let mut tmp_buffer = Buffer::empty(Rect::new(0, 0, 500, 50));
     let mut ascii_area = Rect::new(0, 1, 0, tmp_buffer.area.height - 1);
@@ -105,7 +111,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn get_version() -> Result<()> {
+fn get_version() {
     if let Some(git_sha) = option_env!("VERGEN_GIT_SHA_SHORT") {
         println!("macchina     {} ({})", env!("CARGO_PKG_VERSION"), git_sha);
     } else {
@@ -113,6 +119,4 @@ fn get_version() -> Result<()> {
     }
 
     println!("libmacchina  {}", libmacchina::version());
-
-    Ok(())
 }

--- a/src/theme/base.rs
+++ b/src/theme/base.rs
@@ -205,7 +205,7 @@ pub fn create_theme(opt: &Opt) -> Theme {
     theme
 }
 
-pub fn list_themes(opt: &Opt) -> Result<()> {
+pub fn list_themes(opt: &Opt) {
     let locations = config::locations();
     for dir in locations {
         let entries = libmacchina::extra::list_dir_entries(&dir.join("macchina/themes"));
@@ -243,6 +243,4 @@ pub fn list_themes(opt: &Opt) -> Result<()> {
             }
         });
     }
-
-    Ok(())
 }

--- a/src/widgets/readout.rs
+++ b/src/widgets/readout.rs
@@ -260,14 +260,13 @@ impl<'a> ReadoutList<'a> {
 
         if self.theme.get_separator().is_empty() {
             values.push(max_key_width as u16);
-            values.push(self.theme.get_spacing() as u16);
-            values.push(readout_data.width() as u16);
         } else {
             values.push(max_key_width as u16 + self.theme.get_spacing() as u16);
             values.push(themed_separator.width() as u16);
-            values.push(self.theme.get_spacing() as u16);
-            values.push(readout_data.width() as u16);
         }
+
+        values.push(self.theme.get_spacing() as u16);
+        values.push(readout_data.width() as u16);
 
         if self.theme.get_padding() > 0 {
             values.insert(0, self.theme.get_padding() as u16)

--- a/src/widgets/readout.rs
+++ b/src/widgets/readout.rs
@@ -116,7 +116,11 @@ impl<'a> Widget for ReadoutList<'a> {
             }
 
             Paragraph::new(readout_key.clone()).render(*layout_iter.next().unwrap(), buf);
-            Paragraph::new(themed_separator.clone()).render(*layout_iter.next().unwrap(), buf);
+
+            if !self.theme.get_separator().is_empty() {
+                Paragraph::new(themed_separator.clone()).render(*layout_iter.next().unwrap(), buf);
+            }
+
             layout_iter.next();
             Paragraph::new(readout_data.to_owned()).render(*layout_iter.next().unwrap(), buf);
             height += readout_data.height() as u16;
@@ -252,12 +256,18 @@ impl<'a> ReadoutList<'a> {
         themed_separator: &Text,
         readout_data: &Text,
     ) -> Vec<u16> {
-        let mut values = vec![
-            max_key_width as u16 + self.theme.get_spacing() as u16,
-            themed_separator.width() as u16,
-            self.theme.get_spacing() as u16,
-            readout_data.width() as u16,
-        ];
+        let mut values = vec![];
+
+        if self.theme.get_separator().is_empty() {
+            values.push(max_key_width as u16);
+            values.push(self.theme.get_spacing() as u16);
+            values.push(readout_data.width() as u16);
+        } else {
+            values.push(max_key_width as u16 + self.theme.get_spacing() as u16);
+            values.push(themed_separator.width() as u16);
+            values.push(self.theme.get_spacing() as u16);
+            values.push(readout_data.width() as u16);
+        }
 
         if self.theme.get_padding() > 0 {
             values.insert(0, self.theme.get_padding() as u16)


### PR DESCRIPTION
You'll also notice some tweaks into our CI which make it so it fails if there are any formatting/clippy warnings.