### PR TITLE
Test the provided example configuration/themes

### DIFF
--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -87,6 +87,13 @@ jobs:
           args: --target=${{ matrix.target }}
           use-cross: ${{ matrix.cross }}
 
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target=${{ matrix.target }}
+        if: ${{ !matrix.cross }}
+
       - name: Doctor
         uses: actions-rs/cargo@v1
         with:

--- a/contrib/themes/Hydrogen.toml
+++ b/contrib/themes/Hydrogen.toml
@@ -6,7 +6,11 @@ hide_ascii      = true
 separator       = ">"
 key_color       = "Cyan"
 separator_color = "White"
-palette         = "Light"
+
+[palette]
+type            = "Light"
+glyph           = "[] "
+visible         = true
 
 [bar]
 glyph           = "ߋ"

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,3 +74,14 @@ pub fn config_dir() -> Option<PathBuf> {
 pub fn usr_share_dir() -> Option<PathBuf> {
     Some(PathBuf::from("/usr/share"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_documentation_config() -> Result<()> {
+        read_config("doc/macchina.toml")?;
+        Ok(())
+    }
+}

--- a/src/theme/base.rs
+++ b/src/theme/base.rs
@@ -174,9 +174,8 @@ impl Theme {
 }
 
 /// Searches for and returns a theme from a given directory.
-pub fn get_theme(name: &str, dir: &Path) -> Result<Theme> {
-    let theme_path = dir.join(&format!("macchina/themes/{}.toml", name));
-    let buffer = std::fs::read(theme_path)?;
+pub fn get_theme(path: &Path) -> Result<Theme> {
+    let buffer = std::fs::read(path)?;
     Ok(toml::from_slice(&buffer)?)
 }
 
@@ -184,13 +183,16 @@ pub fn create_theme(opt: &Opt) -> Theme {
     let mut theme = Theme::default();
     let locations = config::locations();
     if let Some(th) = &opt.theme {
-        let t = locations.iter().find(|&d| match get_theme(th, d) {
-            Ok(t) => {
-                theme = t;
-                theme.set_randomization();
-                true
+        let t = locations.iter().find(|&d| {
+            let theme_path = d.join(&format!("macchina/themes/{}.toml", th));
+            match get_theme(&theme_path) {
+                Ok(t) => {
+                    theme = t;
+                    theme.set_randomization();
+                    true
+                }
+                _ => false,
             }
-            _ => false,
         });
 
         if t.is_none() {

--- a/src/theme/base.rs
+++ b/src/theme/base.rs
@@ -246,3 +246,17 @@ pub fn list_themes(opt: &Opt) {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_additional_themes() -> Result<()> {
+        for theme in std::fs::read_dir("contrib/themes")? {
+            let theme = theme?.path();
+            get_theme(&theme)?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
To prevent the provided example configuration/themes of getting out of date and not matching the current version anymore, I added some basic tests that just try to load those files and fail if they cannot be parsed correctly.

The following files are tested:
- The main configuration file: [doc/macchina.toml](doc/macchina.toml)
- All the provided themes at: [contrib/themes](contrib/themes)