### PR TITLE
2 (very) minor fixes to the theming documentation

### DIFF
--- a/doc/macchina.7
+++ b/doc/macchina.7
@@ -5,321 +5,83 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "MACCHINA" "7" "2022-04-02"
+.TH "MACCHINA" "7" "2023-02-26"
 .P
 .SH NAME
-.P
 macchina - theming.\&
 .P
 .SH SYNOPSIS
-.P
 \fB$XDG_CONFIG_HOME/macchina/themes\fR, \fB~/.\&config/macchina/themes\fR.\&
 .P
 .SH DESCRIPTION
-.P
-Themes are your interface to customizing all visual aspects of macchina, the
+Themes are your interface to customizing all visual aspects of macchina.\& The
 following manpage covers everything you need to know to design your own theme.\&
 .P
 .SH GENERAL OPTIONS
+General options should be set at the top of the theme'\&s configuration file, as
+they do not belong to any particular section.\&
 .P
 .SS spacing
-.RS 4
 Defines the amount of spacing to leave between
-the separator and the content besides it, e.\&g.\&
+the separator and the content besides it, e.\&g.\&:
+.RS 4
 .P
 spacing = 1
 .P
 .RE
 .SS padding
-.RS 4
 Defines the amount of padding to leave between
-the content and its surroundings, e.\&g.\&
+the content and its surroundings, e.\&g.\&:
+.RS 4
 .P
 padding = 0
 .P
 .RE
 .SS hide_ascii
-.RS 4
 Disables the rendering of ASCII, whether it be
-built-in or custom, e.\&g.\&
+built-in or custom, e.\&g.\&:
+.RS 4
 .P
 hide_ascii = false
 .P
 .RE
 .SS prefer_small_ascii
+For built-in ASCII, always use smaller variants, e.\&g.\&:
 .RS 4
-For built-in ASCII, always use smaller variants, e.\&g.\&
 .P
 prefer_small_ascii = true
 .P
 .RE
 .SS separator
+Defines the glyph to use for the separator, e.\&g.\&:
 .RS 4
-Defines the glyph to use for the separator, e.\&g.\&
 .P
 separator = "-->"
 .P
 .RE
 .SS key_color
-.RS 4
 Defines the color of the keys.\&
 .P
-Takes hexadecimal/indexed/predefined color
-names, where casing is insensitive e.\&g.\&
+Accepts hexadecimal values:
 .P
 .RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-key_color = "#00FF00" or
+color = "#00FF00"
+.P
 .RE
+Indexed values:
+.P
 .RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-key_color = "046" or
+color = "046"
+.P
 .RE
+Predefined color names, where casing is insensitive:
+.P
 .RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-key_color = "Green"
-
-.RE
+color = "Green"
 .P
 .RE
 .SS separator_color
-.RS 4
 Defines the color of the separator.\&
-.P
-Takes hexadecimal/indexed/predefined color
-names, where casing is insensitive e.\&g.\&
-.P
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-separator_color = "#00FF00" or
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-separator_color = "046" or
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-separator_color = "Green"
-
-.RE
-.P
-.RE
-.SH PALETTE SECTION
-.P
-This section, noted \fB[palette]\fR, offers a visual component that displays and
-represents the active colorscheme of your terminal emulator.\&
-.P
-.SS type
-.RS 4
-Defines the glyph to use for the palette.\& You should
-append a space to leave some room between the glyphs.\&
-.P
-Accepted values:
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-"Dark"
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-"Light"
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-"Full"
-
-.RE
-.P
-.RE
-.SS glyph
-.RS 4
-Defines the glyph to use for the palette.\& You should
-append a space to leave some room between each glyph, e.\&g.\&
-.P
-glyph = "() "
-.P
-.RE
-.SS visible
-.RS 4
-Defines whether to show or hide the palette, e.\&g.\&
-.P
-visible = true
-.P
-.RE
-.SH BAR SECTION
-.P
-This section, noted \fB[bar]\fR, replaces data that ranges from 0-100% with bars.\&
-.P
-.SS glyph
-.RS 4
-Defines the glyph to use for all bars, e.\&g.\&
-.P
-glyph = "o"
-.P
-.RE
-.SS symbol_open
-.RS 4
-Defines the character to use for opening delimiters.\& Be sure
-to surround the value with single quotes and not double quotes, e.\&g.\&
-.P
-symbol_open = '\&('\&
-.P
-.RE
-.SS symbol_close
-.RS 4
-Defines the character to use for closing delimiters.\& Be sure
-to surround the value with single quotes and not double quotes, e.\&g.\&
-.P
-symbol_close = '\&)'\&
-.P
-.RE
-.SS visible
-.RS 4
-Defines whether to show or hide the bars, e.\&g.\&
-.P
-visible = true
-.P
-.RE
-.SS hide_delimiters
-.RS 4
-Defines whether to show or hide the bars delimiters, i.\&e.\&
-the characters that surround the bars themselves, e.\&g.\&
-.P
-hide_delimiters = false
-.P
-.RE
-.SH BOX SECTION
-.P
-The section, noted \fB[box]\fR, offers a box component which is rendered to surround
-your system information.\&
-.P
-.SS title
-.RS 4
-Defines the title of the box, e.\&g.\&
-.P
-title = "Hydrogen"
-.P
-.RE
-.SS border
-.RS 4
-Defines the type of border to use for the box.\&
-.P
-Accepted values:
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-border = "plain" or
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-border = "thick" or
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-border = "rounded" or
-.RE
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-border = "double"
-
-.RE
-.P
-.RE
-.SS visible
-.RS 4
-Defines whether to show or hide the box, e.\&g.\&
-.P
-visible = true
-.P
-.RE
-.SH BOX.INNER_MARGIN SECTION
-.P
-.SS x 
-.RS 4
-Defines the horizontal margin to leave between
-the content and the box, e.\&g.\&
-.P
-x = 2
-.P
-.RE
-.SS y
-Defines the vertical margin to leave between the content and the box, e.\&g.\&
-.RS 4
-.P
-y = 1
-.P
-.RE
-.SH CUSTOM_ASCII SECTION
-.P
-This section, noted \fB[custom_ascii]\fR, allows you to specify your own ASCII art.\&
-ANSI escape sequences are supported.\&
-.P
-.SS color
-.P
-Defines the color of the ASCII.\&
 .RS 4
 .P
 .RE
@@ -341,64 +103,169 @@ Predefined color names, where casing is insensitive:
 color = "Green"
 .P
 .RE
-.SS path
+.SH PALETTE SECTION
+This section, noted \fB[palette]\fR, offers a visual component that displays and
+represents the active colorscheme of your terminal emulator.\&
 .P
-Defines the path to a file on your filesystem
-which contains the ASCII art you want to display, e.\&g.\&
-.RS 4
+.SS type
+Defines the color set to use for the palette, with possible values of "Dark",
+"Light", "Full" (case-sensitive).\&
+.P
+.SS glyph
+Defines the glyph to use for the palette, e.\&g.\&:
 .P
 .RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-path = "~/ascii/arch_linux"
-
+glyph = "() "
+.P
 .RE
+You should append a space to leave some room between the glyphs.\&
+.P
+.SS visible
+Defines whether to show or hide the palette, e.\&g.\&:
+.RS 4
+.P
+visible = true
+.P
+.RE
+.SH BAR SECTION
+.P
+This section, noted \fB[bar]\fR, replaces data that ranges from 0-100% with bars.\&
+.P
+.SS glyph
+Defines the glyph to use for all bars, e.\&g.\&:
+.RS 4
+.P
+glyph = "o"
+.P
+.RE
+.SS symbol_open
+Defines the character to use for opening delimiters.\& Be sure
+.RS 4
+to surround the value with single quotes and not double quotes, e.\&g.\&:
+.P
+symbol_open = '\&('\&
+.P
+.RE
+.SS symbol_close
+Defines the character to use for closing delimiters.\& Be sure
+to surround the value with single quotes and not double quotes, e.\&g.\&:
+.P
+.RS 4
+symbol_close = '\&)'\&
+.P
+.RE
+.SS visible
+Defines whether to show or hide the bars, e.\&g.\&:
+.P
+.RS 4
+visible = true
+.P
+.RE
+.SS hide_delimiters
+Defines whether to show or hide the bars delimiters, i.\&e.\&
+the characters that surround the bars themselves, e.\&g.\&:
+.P
+.RS 4
+hide_delimiters = false
+.P
+.RE
+.SH BOX SECTION
+.P
+The section, noted \fB[box]\fR, offers a box component which is rendered to surround
+your system information.\&
+.P
+.SS title
+Defines the title of the box, e.\&g.\&:
+.P
+.RS 4
+title = "Hydrogen"
+.P
+.RE
+.SS border
+Defines the type of border to use for the box, with possible values of "plain",
+"thick", "rounded" or "double".\&
+.P
+.SS visible
+Defines whether to show or hide the box, e.\&g.\&:
+.P
+.RS 4
+visible = true
+.P
+.RE
+.SH BOX.INNER_MARGIN SECTION
+.P
+.SS x 
+Defines the horizontal margin to leave between
+the content and the box, e.\&g.\&:
+.RS 4
+.P
+x = 2
+.P
+.RE
+.SS y
+Defines the vertical margin to leave between the content and the box, e.\&g.\&:
+.RS 4
+.P
+y = 1
+.P
+.RE
+.SH CUSTOM_ASCII SECTION
+This section, noted \fB[custom_ascii]\fR, allows you to specify your own ASCII art.\&
+ANSI escape sequences are supported.\&
+.P
+.SS color
+Defines the color of the ASCII.\&
+.RS 4
+.P
+.RE
+Accepts hexadecimal values:
+.P
+.RS 4
+color = "#00FF00"
+.P
+.RE
+Indexed values:
+.P
+.RS 4
+color = "046"
+.P
+.RE
+Predefined color names (case-insensitive):
+.P
+.RS 4
+color = "Green"
+.P
+.RE
+.SS path
+Defines the path to a file on your filesystem
+which contains the ASCII art you want to display, e.\&g.\&:
+.RS 4
+.P
+path = "~/ascii/arch_linux"
 .P
 .RE
 .SH RANDOMIZE SECTION
-.P
 This section, noted \fB[randomize]\fR, is used to randomize color selection.\&
 .P
 .SS key_color
-Defines whether to randomize the color of the keys, e.\&g.\&
+Defines whether to randomize the color of the keys, e.\&g.\&:
 .P
 .RS 4
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
 key_color = true
-
-.RE
 .P
 .RE
 .SS separator_color
-Defines whether to randomize the color of the separator, e.\&g.\&
+Defines whether to randomize the color of the separator, e.\&g.\&:
 .P
 .RS 4
 separator_color = true
 .P
 .RE
 .SS pool
+Defines the pool of colors from which to pick a random color, with possible
+values of "hexadecimal", "indexed" or "base" (case-insensitive).\&
 .RS 4
-Defines the pool of colors from which to pick a random color, e.\&g.\&
 .P
-Accepted values:
-.RS 4
-.ie n \{\
-\h'-04'\(bu\h'+03'\c
-.\}
-.el \{\
-.IP \(bu 4
-.\}
-pool = "hexadecimal" or
 .RE
 .RS 4
 .ie n \{\
@@ -407,7 +274,12 @@ pool = "hexadecimal" or
 .el \{\
 .IP \(bu 4
 .\}
-pool = "indexed" or
+If "hexadecimal" is specified, you'\&ll get a random color ranging
+
+.RE
+from #000000 to #FFFFFF
+.RS 4
+.P
 .RE
 .RS 4
 .ie n \{\
@@ -416,154 +288,157 @@ pool = "indexed" or
 .el \{\
 .IP \(bu 4
 .\}
-pool = "base"
+If "indexed" is specified, you'\&ll get a random color ranging from 0 to 255
+.RS 4
 
 .RE
 .P
-If "hexadecimal" is specified, you'\&ll get a random color ranging
-from #000000 to #FFFFFF
-.P
-If "indexed" is specified, you'\&ll get a random color ranging
-from 0 to 255
-.P
-If "base" is specified, you'\&ll get random color from the following
-set of colors: "Black", "White", "Red", "Green", "Blue", "Yellow", 
-"Magenta" and "Cyan".\&
-.P
 .RE
-.SH KEYS SECTION
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.IP \(bu 4
+.\}
+If "base" is specified, you'\&ll see a random color from the following set of
+
+.RE
+colors: "black", "white", "red", "green", "blue", "yellow", "magenta" and
+"cyan".\&
 .P
-This section, noted \fB[keys]\fR, allows you to modify the text of each key.\& e.\&g.\& the
-"Processor" readout, which by default shows up as "CPU" in macchina'\&s output,
-can be renamed to something different by setting the "cpu" option defined in
-this section.\&
+.SH KEYS SECTION
+This section, noted \fB[keys]\fR, allows you to modify the text of each key.\&
+.P
+For example, the "Processor" readout, which by default shows up as "CPU" in
+macchina'\&s output, can be renamed to whatever you like by setting the "cpu"
+option.\&
 .P
 .SS host
-.RS 4
-Defines the text of the Host readout, e.\&g.\&
+Defines the text of the Host readout, e.\&g.\&:
 .P
+.RS 4
 host = "Host"
 .P
 .RE
 .SS kernel
-.RS 4
-Defines the text of the Kernel readout, e.\&g.\&
+Defines the text of the Kernel readout, e.\&g.\&:
 .P
+.RS 4
 kernel = "Kernel"
 .P
 .RE
 .SS os
-.RS 4
-Defines the text of the OperatingSystem readout, e.\&g.\&
+Defines the text of the OperatingSystem readout, e.\&g.\&:
 .P
+.RS 4
 os = "OS"
 .P
 .RE
 .SS machine
-.RS 4
-Defines the text of the Machine readout, e.\&g.\&
+Defines the text of the Machine readout, e.\&g.\&:
 .P
+.RS 4
 machine= "Machine"
 .P
 .RE
 .SS de
-.RS 4
-Defines the text of the DesktopEnvironment readout, e.\&g.\&
+Defines the text of the DesktopEnvironment readout, e.\&g.\&:
 .P
+.RS 4
 de = "DE"
 .P
 .RE
 .SS wm
-.RS 4
-Defines the text of the WindowManager readout, e.\&g.\&
+Defines the text of the WindowManager readout, e.\&g.\&:
 .P
+.RS 4
 wm = "WM"
 .P
 .RE
 .SS distro
+Defines the text of the Distribution readout, e.\&g.\&:
 .RS 4
-Defines the text of the Distribution readout, e.\&g.\&
 .P
 distro = "Distro"
 .P
 .RE
 .SS terminal
-.RS 4
-Defines the text of the Terminal readout, e.\&g.\&
+Defines the text of the Terminal readout, e.\&g.\&:
 .P
+.RS 4
 terminal = "Term"
 .P
 .RE
 .SS shell
-.RS 4
-Defines the text of the Shell readout, e.\&g.\&
+Defines the text of the Shell readout, e.\&g.\&:
 .P
+.RS 4
 shell = "Shell"
 .P
 .RE
 .SS packages
-.RS 4
-Defines the text of the Packages readout, e.\&g.\&
+Defines the text of the Packages readout, e.\&g.\&:
 .P
+.RS 4
 packages = "Packages"
 .P
 .RE
 .SS uptime
-.RS 4
-Defines the text of the Uptime readout, e.\&g.\&
+Defines the text of the Uptime readout, e.\&g.\&:
 .P
+.RS 4
 uptime = "Uptime"
 .P
 .RE
 .SS local_ip
-.RS 4
-Defines the text of the LocalIP readout, e.\&g.\&
+Defines the text of the LocalIP readout, e.\&g.\&:
 .P
+.RS 4
 local_ip = "Local IP"
 .P
 .RE
 .SS memory
-.RS 4
-Defines the text of the Memory readout, e.\&g.\&
+Defines the text of the Memory readout, e.\&g.\&:
 .P
+.RS 4
 memory = "Memory"
 .P
 .RE
 .SS battery
+Defines the text of the Battery readout, e.\&g.\&:
 .RS 4
-Defines the text of the Battery readout, e.\&g.\&
 .P
 battery = "Battery"
 .P
 .RE
 .SS backlight
-.RS 4
-Defines the text of the Backlight readout, e.\&g.\&
+Defines the text of the Backlight readout, e.\&g.\&:
 .P
+.RS 4
 backlight = "Brightness"
 .P
 .RE
 .SS resolution
-.RS 4
-Defines the text of the Resolution readout, e.\&g.\&
+Defines the text of the Resolution readout, e.\&g.\&:
 .P
+.RS 4
 resolution = "Resolution"
 .P
 .RE
 .SS cpu
+Defines the text of the Processor readout, e.\&g.\&:
 .RS 4
-Defines the text of the Processor readout, e.\&g.\&
 .P
 cpu = "CPU"
 .P
 .RE
 .SS cpu_load
-.RS 4
-Defines the text of the ProcessorLoad readout, e.\&g.\&
+Defines the text of the ProcessorLoad readout, e.\&g.\&:
 .P
+.RS 4
 cpu_load = "CPU %"
 .P
 .RE
 .SH SEE ALSO
-.P
 macchina(1)

--- a/doc/macchina.7.scd
+++ b/doc/macchina.7.scd
@@ -7,7 +7,7 @@ macchina - theming.
 *$XDG_CONFIG_HOME/macchina/themes*, *~/.config/macchina/themes*.
 
 # DESCRIPTION
-Themes are your interface to customizing all visual aspects of macchina, the
+Themes are your interface to customizing all visual aspects of macchina. The
 following manpage covers everything you need to know to design your own theme.
 
 # GENERAL OPTIONS
@@ -77,7 +77,7 @@ This section, noted *[palette]*, offers a visual component that displays and
 represents the active colorscheme of your terminal emulator.
 
 ## type
-Defines the glyph to use for the palette, with possible values of "Dark",
+Defines the color set to use for the palette, with possible values of "Dark",
 "Light", "Full" (case-sensitive).
 
 ## glyph


### PR DESCRIPTION
I only made 2 very small changes to the documentation file but running `scdoc < macchina.7.scd > macchina.7` seems to have made a lot of changes. I've never really used the `scdoc` tool but please let me know if this is an issue and how I can fix it.