### PR TITLE
feat - make order that readout keys are listed in macchina.toml affec…

### DIFF
--- a/doc/macchina.1
+++ b/doc/macchina.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "MACCHINA" "1" "2022-10-17"
+.TH "MACCHINA" "1" "2023-02-27"
 .P
 .SH NAME
 .P
@@ -97,6 +97,9 @@ Prints version information.\&
 \fB-o, --show\fR
 .RS 4
 Display only the specified readouts.\&
+.P
+Please note that the order these are listed in will be the order that they are
+displayed in.\&
 .P
 Possible values are (case-sensitive):
 .RS 4

--- a/doc/macchina.1.scd
+++ b/doc/macchina.1.scd
@@ -64,6 +64,9 @@ on performance.
 *-o, --show*
 	Display only the specified readouts.
 
+	Please note that the order these are listed in will be the order that they are
+	displayed in.
+
 	Possible values are (case-sensitive):
 	- Host
 	- Machine

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,6 +1,7 @@
 use crate::cli::Opt;
 use crate::theme::Theme;
 use clap::{Parser, ValueEnum};
+use libmacchina::traits::GeneralReadout as _;
 use libmacchina::traits::ShellFormat;
 use libmacchina::traits::{ReadoutError, ShellKind};
 use libmacchina::{BatteryReadout, GeneralReadout, KernelReadout, MemoryReadout, PackageReadout};
@@ -127,7 +128,7 @@ fn create_bar<'a>(theme: &Theme, blocks: usize) -> Spans<'a> {
 
     span_vector[2].content = Cow::from(colored_glyphs(glyph, 10 - blocks));
     if theme.get_key_color() == Color::White {
-        span_vector[2].content = Cow::from(span_vector[2].content.replace(&glyph, " "));
+        span_vector[2].content = Cow::from(span_vector[2].content.replace(glyph, " "));
     }
     Spans::from(span_vector)
 }
@@ -150,279 +151,338 @@ pub fn get_all_readouts<'a>(
     theme: &Theme,
     should_display: &[ReadoutKey],
 ) -> Vec<Readout<'a>> {
-    use crate::format::cpu as format_cpu;
-    use crate::format::cpu_only as format_cpu_only;
-    use crate::format::cpu_usage as format_cpu_usage;
-    use crate::format::host as format_host;
-    use crate::format::uptime as format_uptime;
-    use libmacchina::traits::GeneralReadout as _;
     let mut readout_values = Vec::with_capacity(ReadoutKey::value_variants().len());
-    let general_readout = GeneralReadout::new();
+    let general_readout: GeneralReadout = GeneralReadout::new();
 
-    if should_display.contains(&ReadoutKey::Host) {
-        match (general_readout.username(), general_readout.hostname()) {
-            (Ok(u), Ok(h)) => {
-                readout_values.push(Readout::new(ReadoutKey::Host, format_host(&u, &h)))
+    for readout_key in should_display {
+        match readout_key {
+            ReadoutKey::Host => handle_readout_host(&mut readout_values, &general_readout),
+            ReadoutKey::Machine => handle_readout_machine(&mut readout_values, &general_readout),
+            ReadoutKey::Kernel => handle_readout_kernel(&mut readout_values, opt),
+            ReadoutKey::OperatingSystem => {
+                handle_readout_operating_system(&mut readout_values, &general_readout)
             }
-            (Err(e), _) | (_, Err(e)) => readout_values.push(Readout::new_err(ReadoutKey::Host, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Machine) {
-        match general_readout.machine() {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Machine, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Machine, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Kernel) {
-        use libmacchina::traits::KernelReadout as _;
-
-        let kernel_readout = KernelReadout::new();
-
-        if opt.long_kernel {
-            match kernel_readout.pretty_kernel() {
-                Ok(s) => readout_values.push(Readout::new(ReadoutKey::Kernel, s)),
-                Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Kernel, e)),
+            ReadoutKey::Distribution => {
+                handle_readout_distribution(&mut readout_values, &general_readout)
             }
-        } else {
-            match kernel_readout.os_release() {
-                Ok(s) => readout_values.push(Readout::new(ReadoutKey::Kernel, s)),
-                Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Kernel, e)),
+            ReadoutKey::Packages => handle_readout_packages(&mut readout_values),
+            ReadoutKey::LocalIP => handle_readout_local_ip(&mut readout_values, opt),
+            ReadoutKey::Terminal => handle_readout_terminal(&mut readout_values, &general_readout),
+            ReadoutKey::Shell => handle_readout_shell(&mut readout_values, &general_readout, opt),
+            ReadoutKey::Uptime => handle_readout_uptime(&mut readout_values, &general_readout, opt),
+            ReadoutKey::Resolution => {
+                handle_readout_resolution(&mut readout_values, &general_readout)
             }
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::OperatingSystem) {
-        match general_readout.os_name() {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::OperatingSystem, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::OperatingSystem, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Distribution) {
-        match general_readout.distribution() {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Distribution, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Distribution, e)),
-        }
-    }
-
-    let desktop_environment = general_readout.desktop_environment();
-    let window_manager = general_readout.window_manager();
-    let session = general_readout.session();
-
-    match (&window_manager, &desktop_environment) {
-        // check if the user is using a window manager only.
-        (Ok(w), Ok(d)) if w.eq_ignore_ascii_case(d) => {
-            if should_display.contains(&ReadoutKey::WindowManager) {
-                match session {
-                    Ok(s) => readout_values.push(Readout::new(
-                        ReadoutKey::WindowManager,
-                        format!("{w} ({s})"),
-                    )),
-                    _ => readout_values.push(Readout::new(ReadoutKey::WindowManager, w.to_owned())),
-                }
+            ReadoutKey::Backlight => {
+                handle_readout_backlight(&mut readout_values, &general_readout, theme)
             }
-
-            readout_values.push(Readout::new_err(
-                ReadoutKey::DesktopEnvironment,
-                ReadoutError::Warning(String::from(
-                    "You appear to be only running a window manager.",
-                )),
-            ))
-        }
-        _ => {
-            if should_display.contains(&ReadoutKey::DesktopEnvironment) {
-                match desktop_environment {
-                    Ok(s) => readout_values.push(Readout::new(ReadoutKey::DesktopEnvironment, s)),
-                    Err(e) => {
-                        readout_values.push(Readout::new_err(ReadoutKey::DesktopEnvironment, e))
-                    }
-                }
+            ReadoutKey::Processor => {
+                handle_readout_processor(&mut readout_values, &general_readout, opt)
             }
-
-            if should_display.contains(&ReadoutKey::WindowManager) {
-                match window_manager {
-                    Ok(w) => match session {
-                        Ok(s) => readout_values.push(Readout::new(
-                            ReadoutKey::WindowManager,
-                            format!("{} ({})", w, s),
-                        )),
-                        _ => readout_values.push(Readout::new(ReadoutKey::WindowManager, w)),
-                    },
-                    Err(e) => readout_values.push(Readout::new_err(ReadoutKey::WindowManager, e)),
-                }
+            ReadoutKey::ProcessorLoad => {
+                handle_readout_processor_load(&mut readout_values, &general_readout, theme)
             }
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Packages) {
-        use crate::format::packages as format_pkgs;
-        use libmacchina::traits::PackageReadout as _;
-
-        let package_readout = PackageReadout::new();
-
-        let packages = package_readout.count_pkgs();
-        match format_pkgs(packages) {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Packages, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Packages, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::LocalIP) {
-        use libmacchina::traits::NetworkReadout as _;
-        use libmacchina::NetworkReadout;
-
-        let network_readout = NetworkReadout::new();
-        match network_readout.logical_address(opt.interface.as_deref()) {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::LocalIP, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::LocalIP, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Terminal) {
-        match general_readout.terminal() {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Terminal, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Terminal, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Shell) {
-        let (ls, cs) = (
-            if opt.long_shell {
-                ShellFormat::Absolute
-            } else {
-                ShellFormat::Relative
-            },
-            if opt.current_shell {
-                ShellKind::Current
-            } else {
-                ShellKind::Default
-            },
-        );
-
-        match general_readout.shell(ls, cs) {
-            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
-        };
-    }
-
-    if should_display.contains(&ReadoutKey::Uptime) {
-        match general_readout.uptime() {
-            Ok(s) => readout_values.push(Readout::new(
-                ReadoutKey::Uptime,
-                format_uptime(s, opt.long_uptime),
-            )),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Uptime, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Processor) {
-        let cores = {
-            if opt.physical_cores {
-                general_readout.cpu_physical_cores()
-            } else {
-                general_readout.cpu_cores()
+            ReadoutKey::Memory => handle_readout_memory(&mut readout_values, theme),
+            ReadoutKey::Battery => handle_readout_battery(&mut readout_values, theme),
+            ReadoutKey::DesktopEnvironment => {
+                handle_readout_desktop_environment(&mut readout_values, &general_readout)
+            }
+            ReadoutKey::WindowManager => {
+                handle_readout_window_manager(&mut readout_values, &general_readout)
             }
         };
-
-        match (general_readout.cpu_model_name(), cores) {
-            (Ok(m), Ok(c)) => {
-                readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu(&m, c)))
-            }
-            (Ok(m), _) => {
-                readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu_only(&m)))
-            }
-            (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::Processor, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Resolution) {
-        match general_readout.resolution() {
-            Ok(r) => readout_values.push(Readout::new(ReadoutKey::Resolution, r)),
-            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Resolution, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Backlight) {
-        match (general_readout.backlight(), theme.get_bar().is_visible()) {
-            (Ok(b), false) => {
-                readout_values.push(Readout::new(ReadoutKey::Backlight, format!("{}%", b)))
-            }
-            (Ok(b), true) => readout_values.push(Readout::new(
-                ReadoutKey::Backlight,
-                create_bar(theme, crate::bars::num_to_blocks(b as u8)),
-            )),
-            (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::Backlight, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::ProcessorLoad) {
-        match (general_readout.cpu_usage(), theme.get_bar().is_visible()) {
-            (Ok(u), true) => {
-                if u > 100 {
-                    readout_values.push(Readout::new(
-                        ReadoutKey::ProcessorLoad,
-                        create_bar(theme, crate::bars::num_to_blocks(100_u8)),
-                    ))
-                }
-                readout_values.push(Readout::new(
-                    ReadoutKey::ProcessorLoad,
-                    create_bar(theme, crate::bars::num_to_blocks(u as u8)),
-                ))
-            }
-            (Ok(u), _) => {
-                readout_values.push(Readout::new(ReadoutKey::ProcessorLoad, format_cpu_usage(u)))
-            }
-            (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::ProcessorLoad, e)),
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Memory) {
-        use crate::format::memory as format_mem;
-        use libmacchina::traits::MemoryReadout as _;
-
-        let memory_readout = MemoryReadout::new();
-        let total = memory_readout.total();
-        let used = memory_readout.used();
-
-        match (total, used) {
-            (Ok(total), Ok(used)) => {
-                if theme.get_bar().is_visible() {
-                    let bar = create_bar(theme, crate::bars::memory(used, total));
-                    readout_values.push(Readout::new(ReadoutKey::Memory, bar))
-                } else {
-                    readout_values.push(Readout::new(ReadoutKey::Memory, format_mem(total, used)))
-                }
-            }
-            (Err(e), _) | (_, Err(e)) => {
-                readout_values.push(Readout::new_err(ReadoutKey::Memory, e))
-            }
-        }
-    }
-
-    if should_display.contains(&ReadoutKey::Battery) {
-        use crate::format::battery as format_bat;
-        use libmacchina::traits::BatteryReadout as _;
-
-        let battery_readout = BatteryReadout::new();
-        let key = ReadoutKey::Battery;
-
-        let percentage = battery_readout.percentage();
-        let state = battery_readout.status();
-
-        match (percentage, state) {
-            (Ok(p), Ok(s)) => {
-                if theme.get_bar().is_visible() {
-                    let bar = create_bar(theme, crate::bars::num_to_blocks(p));
-                    readout_values.push(Readout::new(key, bar));
-                } else {
-                    readout_values.push(Readout::new(key, format_bat(p, s)));
-                }
-            }
-            (Err(e), _) | (_, Err(e)) => readout_values.push(Readout::new_err(key, e)),
-        }
     }
 
     readout_values
+}
+
+// READOUT HANDLERS
+fn handle_readout_host(readout_values: &mut Vec<Readout>, general_readout: &GeneralReadout) {
+    use crate::format::host as format_host;
+
+    match (general_readout.username(), general_readout.hostname()) {
+        (Ok(u), Ok(h)) => readout_values.push(Readout::new(ReadoutKey::Host, format_host(&u, &h))),
+        (Err(e), _) | (_, Err(e)) => readout_values.push(Readout::new_err(ReadoutKey::Host, e)),
+    }
+}
+
+fn handle_readout_machine(readout_values: &mut Vec<Readout>, general_readout: &GeneralReadout) {
+    match general_readout.machine() {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::Machine, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Machine, e)),
+    }
+}
+
+fn handle_readout_kernel(readout_values: &mut Vec<Readout>, opt: &Opt) {
+    use libmacchina::traits::KernelReadout as _;
+
+    let kernel_readout = KernelReadout::new();
+
+    if opt.long_kernel {
+        match kernel_readout.pretty_kernel() {
+            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Kernel, s)),
+            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Kernel, e)),
+        }
+    } else {
+        match kernel_readout.os_release() {
+            Ok(s) => readout_values.push(Readout::new(ReadoutKey::Kernel, s)),
+            Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Kernel, e)),
+        }
+    }
+}
+
+fn handle_readout_operating_system(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+) {
+    match general_readout.os_name() {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::OperatingSystem, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::OperatingSystem, e)),
+    }
+}
+fn handle_readout_distribution(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+) {
+    match general_readout.distribution() {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::Distribution, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Distribution, e)),
+    }
+}
+
+fn handle_readout_packages(readout_values: &mut Vec<Readout>) {
+    use crate::format::packages as format_pkgs;
+    use libmacchina::traits::PackageReadout as _;
+
+    let package_readout = PackageReadout::new();
+
+    let packages = package_readout.count_pkgs();
+    match format_pkgs(packages) {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::Packages, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Packages, e)),
+    }
+}
+
+fn handle_readout_local_ip(readout_values: &mut Vec<Readout>, opt: &Opt) {
+    use libmacchina::traits::NetworkReadout as _;
+    use libmacchina::NetworkReadout;
+
+    let network_readout = NetworkReadout::new();
+    match network_readout.logical_address(opt.interface.as_deref()) {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::LocalIP, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::LocalIP, e)),
+    }
+}
+fn handle_readout_terminal(readout_values: &mut Vec<Readout>, general_readout: &GeneralReadout) {
+    match general_readout.terminal() {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::Terminal, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Terminal, e)),
+    }
+}
+
+fn handle_readout_shell(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+    opt: &Opt,
+) {
+    let (ls, cs) = (
+        if opt.long_shell {
+            ShellFormat::Absolute
+        } else {
+            ShellFormat::Relative
+        },
+        if opt.current_shell {
+            ShellKind::Current
+        } else {
+            ShellKind::Default
+        },
+    );
+
+    match general_readout.shell(ls, cs) {
+        Ok(s) => readout_values.push(Readout::new(ReadoutKey::Shell, s)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Shell, e)),
+    };
+}
+fn handle_readout_uptime(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+    opt: &Opt,
+) {
+    use crate::format::uptime as format_uptime;
+    match general_readout.uptime() {
+        Ok(s) => readout_values.push(Readout::new(
+            ReadoutKey::Uptime,
+            format_uptime(s, opt.long_uptime),
+        )),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Uptime, e)),
+    }
+}
+
+fn handle_readout_resolution(readout_values: &mut Vec<Readout>, general_readout: &GeneralReadout) {
+    match general_readout.resolution() {
+        Ok(r) => readout_values.push(Readout::new(ReadoutKey::Resolution, r)),
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::Resolution, e)),
+    }
+}
+
+fn handle_readout_backlight(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+    theme: &Theme,
+) {
+    match (general_readout.backlight(), theme.get_bar().is_visible()) {
+        (Ok(b), false) => {
+            readout_values.push(Readout::new(ReadoutKey::Backlight, format!("{}%", b)))
+        }
+        (Ok(b), true) => readout_values.push(Readout::new(
+            ReadoutKey::Backlight,
+            create_bar(theme, crate::bars::num_to_blocks(b as u8)),
+        )),
+        (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::Backlight, e)),
+    }
+}
+
+fn handle_readout_processor(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+    opt: &Opt,
+) {
+    use crate::format::cpu as format_cpu;
+    use crate::format::cpu_only as format_cpu_only;
+
+    let cores = {
+        if opt.physical_cores {
+            general_readout.cpu_physical_cores()
+        } else {
+            general_readout.cpu_cores()
+        }
+    };
+
+    match (general_readout.cpu_model_name(), cores) {
+        (Ok(m), Ok(c)) => {
+            readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu(&m, c)))
+        }
+        (Ok(m), _) => readout_values.push(Readout::new(ReadoutKey::Processor, format_cpu_only(&m))),
+        (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::Processor, e)),
+    }
+}
+
+fn handle_readout_processor_load(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+    theme: &Theme,
+) {
+    use crate::format::cpu_usage as format_cpu_usage;
+    match (general_readout.cpu_usage(), theme.get_bar().is_visible()) {
+        (Ok(u), true) => {
+            if u > 100 {
+                readout_values.push(Readout::new(
+                    ReadoutKey::ProcessorLoad,
+                    create_bar(theme, crate::bars::num_to_blocks(100_u8)),
+                ))
+            }
+            readout_values.push(Readout::new(
+                ReadoutKey::ProcessorLoad,
+                create_bar(theme, crate::bars::num_to_blocks(u as u8)),
+            ))
+        }
+        (Ok(u), _) => {
+            readout_values.push(Readout::new(ReadoutKey::ProcessorLoad, format_cpu_usage(u)))
+        }
+        (Err(e), _) => readout_values.push(Readout::new_err(ReadoutKey::ProcessorLoad, e)),
+    }
+}
+
+fn handle_readout_memory(readout_values: &mut Vec<Readout>, theme: &Theme) {
+    use crate::format::memory as format_mem;
+    use libmacchina::traits::MemoryReadout as _;
+
+    let memory_readout = MemoryReadout::new();
+    let total = memory_readout.total();
+    let used = memory_readout.used();
+
+    match (total, used) {
+        (Ok(total), Ok(used)) => {
+            if theme.get_bar().is_visible() {
+                let bar = create_bar(theme, crate::bars::memory(used, total));
+                readout_values.push(Readout::new(ReadoutKey::Memory, bar))
+            } else {
+                readout_values.push(Readout::new(ReadoutKey::Memory, format_mem(total, used)))
+            }
+        }
+        (Err(e), _) | (_, Err(e)) => readout_values.push(Readout::new_err(ReadoutKey::Memory, e)),
+    }
+}
+
+fn handle_readout_battery(readout_values: &mut Vec<Readout>, theme: &Theme) {
+    use crate::format::battery as format_bat;
+    use libmacchina::traits::BatteryReadout as _;
+
+    let battery_readout = BatteryReadout::new();
+    let key = ReadoutKey::Battery;
+
+    let percentage = battery_readout.percentage();
+    let state = battery_readout.status();
+
+    match (percentage, state) {
+        (Ok(p), Ok(s)) => {
+            if theme.get_bar().is_visible() {
+                let bar = create_bar(theme, crate::bars::num_to_blocks(p));
+                readout_values.push(Readout::new(key, bar));
+            } else {
+                readout_values.push(Readout::new(key, format_bat(p, s)));
+            }
+        }
+        (Err(e), _) | (_, Err(e)) => readout_values.push(Readout::new_err(key, e)),
+    }
+}
+
+fn handle_readout_desktop_environment(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+) {
+    let desktop_environment = general_readout.desktop_environment();
+    let window_manager = general_readout.window_manager();
+
+    match &desktop_environment {
+        Ok(d) => match &window_manager {
+            // check if the user is using a window manager only.
+            Ok(w) if w.eq_ignore_ascii_case(d) => {
+                readout_values.push(Readout::new_err(
+                    ReadoutKey::DesktopEnvironment,
+                    ReadoutError::Warning(String::from(
+                        "You appear to be only running a window manager.",
+                    )),
+                ));
+            }
+            _ => {
+                readout_values.push(Readout::new(ReadoutKey::DesktopEnvironment, d.to_owned()));
+            }
+        },
+        Err(e) => readout_values.push(Readout::new_err(
+            ReadoutKey::DesktopEnvironment,
+            e.to_owned(),
+        )),
+    }
+}
+
+fn handle_readout_window_manager(
+    readout_values: &mut Vec<Readout>,
+    general_readout: &GeneralReadout,
+) {
+    let window_manager = general_readout.window_manager();
+    let session = general_readout.session();
+
+    match window_manager {
+        Ok(w) => match session {
+            Ok(s) => {
+                readout_values.push(Readout::new(
+                    ReadoutKey::WindowManager,
+                    format!("{} ({})", w, s),
+                ));
+            }
+            _ => readout_values.push(Readout::new(ReadoutKey::WindowManager, w)),
+        },
+        Err(e) => readout_values.push(Readout::new_err(ReadoutKey::WindowManager, e)),
+    }
 }


### PR DESCRIPTION
…t the order readouts are displayed in.

Also minor change to the documentation to note that the order now matters.

Hope this is alright but of course don't hold back with criticisms / suggestions.

I'm still new to rust and wasn't sure how / if I should split up this file so I left everything in the one file but perhaps it's too long. Also I realise that this change makes the order *have* to matter rather than it being optional, if you would like it to be optional I can look into it, maybe add another config option for `show_order_matters = "true"`.

Thanks for making this tool and thanks in advance for any feedback, I'm new to rust so any tips you have are appreciated.