### PR TITLE
Add gpu readout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,12 +118,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -198,37 +195,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
-]
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -537,7 +503,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -724,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "libmacchina"
-version = "6.3.5"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2009e687ca8eb9897596373801cda8c5e745477a54b89d3251221cd41b0d23"
+checksum = "07f8d808d1a5f51f461fccc7690501ccdf706157fcdb296c02be552c7617e6b6"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation 0.9.3",
@@ -742,12 +708,13 @@ dependencies = [
  "nix",
  "num_cpus",
  "os-release",
+ "pciid-parser",
  "regex",
  "sqlite",
  "sysctl",
  "vergen",
  "walkdir",
- "windows",
+ "windows 0.39.0",
  "winreg",
  "wmi",
  "x11rb",
@@ -888,7 +855,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.36.1",
 ]
 
@@ -1023,6 +990,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "pciid-parser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2ef5429455ae06f0c055262d540bf2c190ad51b72bb6cbe8488706c4dff440"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]
@@ -1396,17 +1372,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
@@ -1438,6 +1403,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1517,7 +1514,7 @@ dependencies = [
  "rustc_version",
  "rustversion",
  "thiserror",
- "time 0.3.14",
+ "time",
 ]
 
 [[package]]
@@ -1536,12 +1533,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1604,12 +1595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
-name = "widestring"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1648,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,19 +1700,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1710,9 +1743,9 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1728,9 +1761,9 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1746,9 +1779,9 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1764,15 +1797,15 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1788,9 +1821,9 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"
@@ -1803,18 +1836,16 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31186a1833786ed5f5f61d4c9b7a16df6a5f3883258622d5424c43cbd431b62c"
+checksum = "0a6d8b03da5961fbf8f52ec30f1b1108d68f07bf09ab768b806e21d92b9b7b40"
 dependencies = [
  "chrono",
- "com",
  "futures",
  "log",
  "serde",
  "thiserror",
- "widestring",
- "winapi",
+ "windows 0.44.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-libmacchina = { version = "6.3.5", features = ["version"] }
+libmacchina = { version = "6.4.0", features = ["version"] }
 bytesize = "1.1.0"
 shellexpand = "3.0.0"
 clap = { version = "4.0.32", features = ["derive"] } # TODO: Update me!

--- a/doc/macchina.1
+++ b/doc/macchina.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "MACCHINA" "1" "2023-02-27"
+.TH "MACCHINA" "1" "2023-03-25"
 .P
 .SH NAME
 .P
@@ -263,6 +263,15 @@ Memory
 .IP \(bu 4
 .\}
 Battery
+.RE
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.IP \(bu 4
+.\}
+GPU
 
 .RE
 .P

--- a/doc/macchina.1.scd
+++ b/doc/macchina.1.scd
@@ -86,6 +86,7 @@ on performance.
 	- ProcessorLoad
 	- Memory
 	- Battery
+	- GPU
 
 *--ascii-artists*
 	Lists the original artists of the ASCII art used by macchina.

--- a/doc/macchina.7
+++ b/doc/macchina.7
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "MACCHINA" "7" "2023-02-26"
+.TH "MACCHINA" "7" "2023-03-25"
 .P
 .SH NAME
 macchina - theming.\&
@@ -438,6 +438,13 @@ Defines the text of the ProcessorLoad readout, e.\&g.\&:
 .P
 .RS 4
 cpu_load = "CPU %"
+.P
+.RE
+.SS gpu
+Defines the text of the GPU readout(s), e.\&g.\&:
+.P
+.RS 4
+gpu = "GPU"
 .P
 .RE
 .SH SEE ALSO

--- a/doc/macchina.7.scd
+++ b/doc/macchina.7.scd
@@ -304,5 +304,10 @@ Defines the text of the ProcessorLoad readout, e.g.:
 
 	cpu_load = "CPU %"
 
+## gpu
+Defines the text of the GPU readout(s), e.g.:
+
+	gpu = "GPU"
+
 # SEE ALSO
 macchina(1)

--- a/macchina.toml
+++ b/macchina.toml
@@ -15,7 +15,7 @@ current_shell = true
 
 # Toggle between displaying the number of physical or logical cores of your
 # processor.
-physical_cores = true 
+physical_cores = true
 
 # Themes need to be placed in "$XDG_CONFIG_DIR/macchina/themes" beforehand.
 # e.g.:
@@ -44,5 +44,6 @@ physical_cores = true
 #   - ProcessorLoad
 #   - Memory
 #   - Battery
+#   - GPU
 # Example:
 #   show = ["Battery", "Memory", ...]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -3,9 +3,7 @@ use crate::theme::Theme;
 use clap::{Parser, ValueEnum};
 use libmacchina::traits::GeneralReadout as _;
 use libmacchina::traits::{ReadoutError, ShellFormat, ShellKind};
-use libmacchina::{
-    BatteryReadout, GeneralReadout, GpuReadout, KernelReadout, MemoryReadout, PackageReadout,
-};
+use libmacchina::{BatteryReadout, GeneralReadout, KernelReadout, MemoryReadout, PackageReadout};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::Display;
@@ -193,7 +191,7 @@ pub fn get_all_readouts<'a>(
             ReadoutKey::WindowManager => {
                 handle_readout_window_manager(&mut readout_values, &general_readout)
             }
-            ReadoutKey::GPU => handle_readout_gpu(&mut readout_values),
+            ReadoutKey::GPU => handle_readout_gpu(&mut readout_values, &general_readout),
         };
     }
 
@@ -491,12 +489,8 @@ fn handle_readout_window_manager(
     }
 }
 
-fn handle_readout_gpu(readout_values: &mut Vec<Readout>) {
-    use libmacchina::traits::GpuReadout as _;
-
-    let gpu_readout = GpuReadout::new();
-
-    let gpus = match gpu_readout.list_gpus() {
+fn handle_readout_gpu(readout_values: &mut Vec<Readout>, general_readout: &GeneralReadout) {
+    let gpus = match general_readout.gpus() {
         Ok(gpus) => gpus,
         Err(_) => {
             readout_values.push(Readout::new_err(

--- a/src/theme/base.rs
+++ b/src/theme/base.rs
@@ -216,6 +216,7 @@ impl Theme {
             ReadoutKey::Backlight => self.keys.get_backlight(),
             ReadoutKey::Uptime => self.keys.get_uptime(),
             ReadoutKey::Memory => self.keys.get_memory(),
+            ReadoutKey::GPU => self.keys.get_gpu(),
         }
     }
 }

--- a/src/theme/components.rs
+++ b/src/theme/components.rs
@@ -299,6 +299,7 @@ pub struct Keys {
     pub resolution: Option<String>,
     pub cpu_load: Option<String>,
     pub cpu: Option<String>,
+    pub gpu: Option<String>,
 }
 
 impl Default for Keys {
@@ -322,6 +323,7 @@ impl Default for Keys {
             resolution: Some(String::from("Resolution")),
             cpu_load: Some(String::from("CPU Load")),
             cpu: Some(String::from("CPU")),
+            gpu: Some(String::from("GPU")),
         }
     }
 }
@@ -469,5 +471,13 @@ impl Keys {
         }
 
         "CPU"
+    }
+
+    pub fn get_gpu(&self) -> &str {
+        if let Some(m) = &self.gpu {
+            return m;
+        }
+
+        "GPU"
     }
 }


### PR DESCRIPTION
In relation to #107.

Add the ability to display connected GPUs with the readout information provided by [libmacchina v6.4.0](https://crates.io/crates/libmacchina), added in [this PR](https://github.com/Macchina-CLI/libmacchina/pull/140). This functionality is currently only implemented for Linux.