### PR TITLE
Implement palette.spacing feature

### DIFF
--- a/contrib/themes/Beryllium.toml
+++ b/contrib/themes/Beryllium.toml
@@ -10,7 +10,8 @@ border          = "plain"
 visible         = true
 
 [palette]
-glyph           = "○  "
+glyph           = "○"
+spacing         = 2
 visible         = true
 
 [bar]

--- a/contrib/themes/Lithium.toml
+++ b/contrib/themes/Lithium.toml
@@ -9,7 +9,8 @@ separator_color = "Yellow"
 
 [palette]
 type            = "Light"
-glyph           = " ● "
+glyph           = "●"
+spacing         = 2
 visible         = true
 
 [bar]

--- a/src/theme/components.rs
+++ b/src/theme/components.rs
@@ -1,15 +1,16 @@
 use crate::theme::borders::Border;
 use crate::theme::color::*;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 use ratatui::style::Color;
 use ratatui::widgets::BorderType;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Palette {
     r#type: Option<PaletteType>,
     glyph: Option<String>,
+    spacing: Option<usize>,
     visible: Option<bool>,
 }
 
@@ -18,6 +19,7 @@ impl Default for Palette {
         Palette {
             r#type: Some(PaletteType::Dark),
             glyph: Some(String::from("   ")),
+            spacing: Some(0),
             visible: None,
         }
     }
@@ -34,6 +36,14 @@ impl Palette {
 
     pub fn get_glyph(&self) -> Option<&String> {
         self.glyph.as_ref()
+    }
+
+    pub fn get_spacing(&self) -> usize {
+        if let Some(v) = self.spacing {
+            return v;
+        }
+
+        0
     }
 
     pub fn is_visible(&self) -> bool {


### PR DESCRIPTION
See #307, this implements a new `palette.spacing` feature.

I'd like some extra help with review since I'm fairly new to Rust, and I'd like to adhere to the "emphasis on performance" tenet.