### PR TITLE
Replace discontinued `actions-rs` from CI

### DIFF
--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -6,6 +6,8 @@ jobs:
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    env:
+      PROGRAM: ${{ matrix.cross && 'cross' || 'cargo' }}
     strategy:
       fail-fast: false
       matrix:
@@ -98,48 +100,34 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Bootstrap
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt, clippy
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
+      
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+        if: ${{ matrix.cross }}
 
       - name: Formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          use-cross: ${{ matrix.cross }}
+        run: cargo fmt --all -- --check
+        if: ${{ !matrix.cross }}
         continue-on-error: false
 
       - name: Lints
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target=${{ matrix.target }} -- --no-deps -D clippy::all
-          use-cross: ${{ matrix.cross }}
+        run: ${{ env.PROGRAM }} clippy --target=${{ matrix.target }} -- --no-deps -D clippy::all
         continue-on-error: false
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }}
-          use-cross: ${{ matrix.cross }}
+        run: ${{ env.PROGRAM }} build --target=${{ matrix.target }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target=${{ matrix.target }}
+        run: ${{ env.PROGRAM }} test --target=${{ matrix.target }}
         if: ${{ !matrix.cross && !contains(matrix.target, 'aarch64') }}
 
       - name: Doctor
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --target=${{ matrix.target }} -- --doctor
-          use-cross: ${{ matrix.cross }}
+        run: ${{ env.PROGRAM }} run --target=${{ matrix.target }} -- --doctor
         if: ${{ matrix.test }}

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -2,11 +2,11 @@ use crate::Result;
 use ansi_to_tui::IntoText;
 use colored::Colorize;
 use io::Read;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span, Text};
 use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
-use ratatui::style::{Color, Style};
-use ratatui::text::{Span, Line, Text};
 
 lazy_static! {
     static ref BLUE: Style = Style::default().fg(Color::Blue);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,13 +2,13 @@ use crate::data::Readout;
 use crate::theme::Theme;
 use crate::widgets::readout::ReadoutList;
 use atty::Stream;
-use std::io;
-use std::io::Stdout;
 use ratatui::backend::{Backend, CrosstermBackend};
 use ratatui::buffer::{Buffer, Cell};
 use ratatui::layout::{Margin, Rect};
 use ratatui::text::Text;
 use ratatui::widgets::{Block, Borders, Paragraph, Widget};
+use std::io;
+use std::io::Stdout;
 use unicode_width::UnicodeWidthStr;
 
 pub fn create_backend() -> CrosstermBackend<Stdout> {

--- a/src/theme/color.rs
+++ b/src/theme/color.rs
@@ -1,6 +1,6 @@
 use rand::seq::SliceRandom;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ratatui::style::Color;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone)]
 pub enum ColorTypes {

--- a/src/theme/components.rs
+++ b/src/theme/components.rs
@@ -1,10 +1,10 @@
 use crate::theme::borders::Border;
 use crate::theme::color::*;
 use rand::Rng;
-use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 use ratatui::style::Color;
 use ratatui::widgets::BorderType;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Palette {


### PR DESCRIPTION
Due to `actions-rs` being currently unmaintained, this PR replaces it with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) and explicit calls to the respective `cargo`/`cross` commands.

## Things to consider
- Maybe it would make sense to execute the "Formatting" and "Lints" jobs only once, instead of for each target platform.
- The `clippy` command currently does not fail when warnings are emitted. This could be fixed by setting `RUSTFLAGS: "-Dwarnings"` (see https://doc.rust-lang.org/nightly/clippy/continuous_integration/github_actions.html)
- The "Doctor" job is never executed, because the `test` variable is never set for any platform.