### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -6,6 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: Lint
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +21,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- --no-deps -D clippy::all
+        run: cargo clippy --all-targets --all-features
 
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})

--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -50,73 +50,61 @@ jobs:
             name: GNU/Linux x86_64
             target: x86_64-unknown-linux-gnu
             cross: false
-            strip: true
 
           - os: ubuntu-latest
             name: Linux musl x86_64
             target: x86_64-unknown-linux-musl
             cross: true
-            strip: true
 
           - os: macos-latest
             name: macOS x86_64
             target: x86_64-apple-darwin
             cross: false
-            strip: true
 
           - os: windows-latest
             name: Windows x86_64
             target: x86_64-pc-windows-msvc
             cross: false
-            strip: true
 
           - os: ubuntu-latest
             name: NetBSD x86_64
             target: x86_64-unknown-netbsd
             cross: true
-            strip: true
 
           - os: ubuntu-latest
             name: freeBSD x86_64
             target: x86_64-unknown-freebsd
             cross: true
-            strip: true
 
           - os: ubuntu-latest
             name: Android aarch64
             target: aarch64-linux-android
             cross: true
-            strip: true
 
           - os: ubuntu-latest
             name: GNU/Linux aarch64
             target: aarch64-unknown-linux-gnu
             cross: true
-            strip: true
 
           - os: ubuntu-latest
             name: Linux musl aarch64
             target: aarch64-unknown-linux-musl
             cross: true
-            strip: true
 
           - os: macos-latest
             name: macOS aarch64
             target: aarch64-apple-darwin
             cross: false
-            strip: true
 
           - os: windows-latest
             name: Windows aarch64
             target: aarch64-pc-windows-msvc
             cross: false
-            strip: true
 
           - os: ubuntu-latest
             name: GNU/Linux ARMv7
             target: armv7-unknown-linux-gnueabihf
             cross: true
-            strip: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -3,6 +3,24 @@ on: [push, pull_request]
 name: CI
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- --no-deps -D clippy::all
+
   checks:
     name: ${{ matrix.name }} (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
@@ -105,21 +123,11 @@ jobs:
       - name: Bootstrap
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
           targets: ${{ matrix.target }}
       
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
         if: ${{ matrix.cross }}
-
-      - name: Formatting
-        run: cargo fmt --all -- --check
-        if: ${{ !matrix.cross }}
-        continue-on-error: false
-
-      - name: Lints
-        run: ${{ env.PROGRAM }} clippy --target=${{ matrix.target }} -- --no-deps -D clippy::all
-        continue-on-error: false
 
       - name: Build
         run: ${{ env.PROGRAM }} build --target=${{ matrix.target }}

--- a/.github/workflows/macchina.yml
+++ b/.github/workflows/macchina.yml
@@ -50,61 +50,73 @@ jobs:
             name: GNU/Linux x86_64
             target: x86_64-unknown-linux-gnu
             cross: false
+            test: true
 
           - os: ubuntu-latest
             name: Linux musl x86_64
             target: x86_64-unknown-linux-musl
             cross: true
+            test: true
 
           - os: macos-latest
             name: macOS x86_64
             target: x86_64-apple-darwin
             cross: false
+            test: true
 
           - os: windows-latest
             name: Windows x86_64
             target: x86_64-pc-windows-msvc
             cross: false
+            test: true
 
           - os: ubuntu-latest
             name: NetBSD x86_64
             target: x86_64-unknown-netbsd
             cross: true
+            test: false
 
           - os: ubuntu-latest
             name: freeBSD x86_64
             target: x86_64-unknown-freebsd
             cross: true
+            test: false
 
           - os: ubuntu-latest
             name: Android aarch64
             target: aarch64-linux-android
             cross: true
+            test: true
 
           - os: ubuntu-latest
             name: GNU/Linux aarch64
             target: aarch64-unknown-linux-gnu
             cross: true
+            test: true
 
           - os: ubuntu-latest
             name: Linux musl aarch64
             target: aarch64-unknown-linux-musl
             cross: true
+            test: true
 
           - os: macos-latest
             name: macOS aarch64
             target: aarch64-apple-darwin
             cross: false
+            test: true
 
           - os: windows-latest
             name: Windows aarch64
             target: aarch64-pc-windows-msvc
             cross: false
+            test: false
 
           - os: ubuntu-latest
             name: GNU/Linux ARMv7
             target: armv7-unknown-linux-gnueabihf
             cross: true
+            test: true
 
     steps:
       - name: Checkout
@@ -124,8 +136,8 @@ jobs:
 
       - name: Test
         run: ${{ env.PROGRAM }} test --target=${{ matrix.target }}
-        if: ${{ !matrix.cross && !contains(matrix.target, 'aarch64') }}
+        if: ${{ matrix.test }}
 
       - name: Doctor
         run: ${{ env.PROGRAM }} run --target=${{ matrix.target }} -- --doctor
-        if: ${{ matrix.test }}
+        if: ${{ !matrix.cross && matrix.test }}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ pub fn read_config<S: AsRef<std::ffi::OsStr> + ?Sized>(path: &S) -> Result<Opt> 
     if path.exists() {
         let buffer = std::fs::read(path)?;
         let contents = std::str::from_utf8(buffer.as_slice())?;
-        Ok(toml::from_str(&contents)?)
+        Ok(toml::from_str(contents)?)
     } else {
         Ok(Opt::default())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,26 +5,26 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Failed due to IOError {0}")]
-    IOError(#[from] io::Error),
+    IO(#[from] io::Error),
 
     #[error("Failed due to Utf8Error {0}")]
-    Utf8Error(#[from] std::str::Utf8Error),
+    Utf8(#[from] std::str::Utf8Error),
 
     #[error("Failed to parse TOML file {0}")]
-    ParsingError(#[from] toml::de::Error),
+    Parsing(#[from] toml::de::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub fn print_errors(err: Error) {
     match err {
-        Error::ParsingError(err) => {
+        Error::Parsing(err) => {
             println!("{}: {}", "Error".bright_red(), err.message());
         }
-        Error::Utf8Error(err) => {
+        Error::Utf8(err) => {
             println!("{}: {:?}", "Error".bright_red(), err);
         }
-        Error::IOError(err) => {
+        Error::IO(err) => {
             println!("{}: {:?}", "Error".bright_red(), err);
         }
     }


### PR DESCRIPTION
This is the implementation of the changes discussed in #311:
- Extracting the `cargo fmt` and `cargo clippy` steps into their own jobs.
  - @grtcdr: What do you think? Is this OK, or should we combine the two jobs?
- Fail `clippy` on warnings (required some minor code changes).
- Execute the "Test" and "Doctor" change on all platforms that support it.

Additionally, I removed the `strip` variable from the matrix, because it was never used.