### PR TITLE
feat: add option for using shorter CPU model name

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,13 @@ pub struct Opt {
     pub long_kernel: bool,
 
     #[clap(
+        short = 'G',
+        long = "shorter-cpu",
+        help = "Shorten the CPU's model name"
+    )]
+    pub shorter_cpu: bool,
+
+    #[clap(
         short = 'm',
         long = "memory-percentage",
         help = "Show memory usage in percentage"
@@ -158,6 +165,10 @@ impl Opt {
 
         if args.ascii_artists {
             self.ascii_artists = true;
+        }
+
+        if args.shorter_cpu {
+            self.shorter_cpu = args.shorter_cpu;
         }
 
         if args.config.is_some() {


### PR DESCRIPTION
As discussed, here's a potential feature, shorter CPU model name.

Now, this could be too fragile of an implementation - let me know if you have better suggestions, or otherwise I understand if you want to forego this one entirely. I personally really like the shortened versions though:

 - `AMD Ryzen 7 7800X3D 8-Core Processor (8)` -> `AMD Ryzen 7 7800X3D (8)`
 - `Intel® Core™ i5-6500 CPU @ 3.20GHz (4)` -> `Intel® Core™ i5-6500 (4)`
 
I included a comment with a list of CPU model names I found from people's screenshots in the issues on this repo, as I only have the 2 CPUs above available to me personally.

The choice for `G` as the shorthand was because in my branch I had done a shortened GPU name first as `g` so it made sense to relate the options. Just let me know if you want it changed though.

I can update the changelog etc. if you this is indeed a feature you'd be interested in.